### PR TITLE
minCollatorStk constant has been deprecated

### DIFF
--- a/builders/pallets-precompiles/pallets/staking.md
+++ b/builders/pallets-precompiles/pallets/staking.md
@@ -128,7 +128,7 @@ The parachain staking pallet includes the following read-only functions to obtai
 - **maxTopDelegationsPerCandidate**() - returns the maximum number of top delegations per candidate 
 - **minBlocksPerRound**() - returns the minimum number of blocks per round
 - **minCandidateStk**() - returns the minimum stake required for a candidate to be a collator candidate
-- **minCollatorStk**() - returns the minimum stake required for a candidate to be in the active set 
+- **minCollatorStk**() - *deprecated as of runtime 2400* - returns the minimum stake required for a candidate to be in the active set
 - **minDelegation**() - returns the minimum delegation amount
 - **minDelegatorStk**() - returns the minimum stake for an account to be a delegator
 - **minSelectedCandidates**() - returns the minimum number of selected candidates in the active set every round

--- a/node-operators/networks/collators/requirements.md
+++ b/node-operators/networks/collators/requirements.md
@@ -98,7 +98,7 @@ This information includes:
 
 It is recommended that you use the binary file in an air-gapped machine.
 
-### Other Moonkey Features {: #other-moonkey-features } 
+### Other Moonkey Features {: #other-moonkey-features }
 
 Moonkey provides some additional functionalities. The following flags can be provided:
 
@@ -111,7 +111,7 @@ The following options are available:
 - `-account-index` – provide as input the account index to use in the derivation path
 - `-mnemonic` – provide as input the mnemonic
 
-## Bonding Requirements {: #bonding-requirements } 
+## Bonding Requirements {: #bonding-requirements }
 
 There are two bonds for you to be aware of: a bond to join the collator pool and a bond for key association.
 
@@ -123,23 +123,19 @@ First, you will need a minimum amount of tokens staked (self-bonded) to be consi
     |         Variable          |                          Value                           |
     |:-------------------------:|:--------------------------------------------------------:|
     | Minimum self-bond amount  |     {{ networks.moonbeam.staking.min_can_stk }} GLMR     |
-    | Minimum total bond amount |     {{ networks.moonbeam.staking.min_col_stk }} GLMR     |
     |      Active set size      | {{ networks.moonbeam.staking.max_candidates }} collators |
 
 === "Moonriver"
     |         Variable          |                           Value                           |
     |:-------------------------:|:---------------------------------------------------------:|
     | Minimum self-bond amount  |     {{ networks.moonriver.staking.min_can_stk }} MOVR     |
-    | Minimum total bond amount |     {{ networks.moonriver.staking.min_col_stk }} MOVR     |
     |      Active set size      | {{ networks.moonriver.staking.max_candidates }} collators |
 
 === "Moonbase Alpha"
     |         Variable          |                          Value                           |
     |:-------------------------:|:--------------------------------------------------------:|
     | Minimum self-bond amount  |     {{ networks.moonbase.staking.min_can_stk }} DEV      |
-    | Minimum total bond amount |     {{ networks.moonbase.staking.min_col_stk }} DEV      |
     |      Active set size      | {{ networks.moonbase.staking.max_candidates }} collators |
-
 
 ### Key Association Bond {: #key-association-bond }
 

--- a/variables.yml
+++ b/variables.yml
@@ -302,7 +302,6 @@ networks:
       collator_reward_inflation: 20
       parachain_bond_inflation: 30
     staking:
-      min_col_stk: 1000
       min_can_stk: 500
       min_can_stk_wei: 500000000000000000000
       collator_map_bond: 100
@@ -620,7 +619,6 @@ networks:
       collator_reward_inflation: 20
       parachain_bond_inflation: 30
     staking:
-      min_col_stk: 10000
       min_can_stk: 10000
       min_can_stk_wei: 10000000000000000000000
       collator_map_bond: 100
@@ -845,7 +843,6 @@ networks:
       collator_reward_inflation: 20
       parachain_bond_inflation: 30
     staking:
-      min_col_stk: 2000000
       min_can_stk: 2000000
       min_can_stk_wei: 2000000000000000000000000
       collator_map_bond: 10000


### PR DESCRIPTION
### Description

This PR removes `minCollatorStk` as it deprecated as of RT2400.
Goes with CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/290
