### PR TITLE
Fix Randomness Precompile Gas 

### DIFF
--- a/.snippets/code/randomness/Lottery.sol
+++ b/.snippets/code/randomness/Lottery.sol
@@ -43,7 +43,7 @@ contract Lottery is RandomnessConsumer {
     // there will be enough fee to pay for the gas used by the fulfillment.
     // Ideally it should be over-estimated considering possible fluctuation of
     // the gas price. Additional fee will be refunded to the caller
-    uint256 public MIN_FEE = FULFILLMENT_GAS_LIMIT * 1 gwei;
+    uint256 public MIN_FEE = FULFILLMENT_GAS_LIMIT * 150 gwei;
 
     // A string used to allow having different salt than other contracts
     bytes32 public SALT_PREFIX = "my_demo_salt_change_me";

--- a/builders/pallets-precompiles/precompiles/randomness.md
+++ b/builders/pallets-precompiles/precompiles/randomness.md
@@ -197,7 +197,9 @@ contract RandomNumber is RandomnessConsumer {
     // The fee can be set to any value as long as it is enough to cover
     // the fulfillment costs. Any leftover fees will be refunded to the
     // refund address specified in the requestRandomness function below
-    uint256 public MIN_FEE = FULFILLMENT_GAS_LIMIT * 5 gwei;
+    // 150 gwei should be more than enough for all networks
+    // For Moonbase Alpha and Moonriver you can specify 5 Gwei 
+    uint256 public MIN_FEE = FULFILLMENT_GAS_LIMIT * 150 gwei; 
     uint32 public VRF_BLOCKS_DELAY = MIN_VRF_BLOCKS_DELAY;
     bytes32 public SALT_PREFIX = "change-me-to-anything";
 
@@ -287,7 +289,7 @@ The **RANDOMNUMBER** contract will appear in the list of **Deployed Contracts**.
 
 To request randomness, you're going to use the `requestRandomness` function of the contract, which will require you to submit a deposit as defined in the Randomness Precompile. You can submit the randomness request and pay the deposit by taking these steps:
 
-1. Enter an amount in the **VALUE** field for the fulfillment fee, it must be equal to or greater than the minimum fee specified in the `RandomNumber` contract, which is `500000` Gwei
+1. Enter an amount in the **VALUE** field for the fulfillment fee, it must be equal to or greater than the minimum fee specified in the `RandomNumber` contract, which is `500000` Gwei on Moonbase Alpha and Moonriver, and `15000000` Gwei on Moonbeam.
 2. Expand the **RANDOMNUMBER** contract
 3. Click on the **requestRandomness** button
 4. Confrm the transaction in MetaMask

--- a/builders/pallets-precompiles/precompiles/randomness.md
+++ b/builders/pallets-precompiles/precompiles/randomness.md
@@ -197,7 +197,7 @@ contract RandomNumber is RandomnessConsumer {
     // The fee can be set to any value as long as it is enough to cover
     // the fulfillment costs. Any leftover fees will be refunded to the
     // refund address specified in the requestRandomness function below
-    // 150 gwei should be more than enough for all networks
+    // 150 gwei should be sufficient for all networks
     // For Moonbase Alpha and Moonriver you can specify 5 Gwei 
     uint256 public MIN_FEE = FULFILLMENT_GAS_LIMIT * 150 gwei; 
     uint32 public VRF_BLOCKS_DELAY = MIN_VRF_BLOCKS_DELAY;
@@ -289,7 +289,7 @@ The **RANDOMNUMBER** contract will appear in the list of **Deployed Contracts**.
 
 To request randomness, you're going to use the `requestRandomness` function of the contract, which will require you to submit a deposit as defined in the Randomness Precompile. You can submit the randomness request and pay the deposit by taking these steps:
 
-1. Enter an amount in the **VALUE** field for the fulfillment fee, it must be equal to or greater than the minimum fee specified in the `RandomNumber` contract, which is `500000` Gwei on Moonbase Alpha and Moonriver, and `15000000` Gwei on Moonbeam.
+1. Enter an amount in the **VALUE** field for the fulfillment fee, it must be equal to or greater than the minimum fee specified in the `RandomNumber` contract, which is `15000000` Gwei. 
 2. Expand the **RANDOMNUMBER** contract
 3. Click on the **requestRandomness** button
 4. Confrm the transaction in MetaMask

--- a/tutorials/eth-api/randomness-lottery.md
+++ b/tutorials/eth-api/randomness-lottery.md
@@ -146,7 +146,7 @@ uint64 public FULFILLMENT_GAS_LIMIT = 100000;
 // there will be enough fee to pay for the gas used by the fulfillment. 
 // Ideally it should be over-estimated considering possible fluctuation of 
 // the gas price. Additional fee will be refunded to the caller
-uint256 public MIN_FEE = FULFILLMENT_GAS_LIMIT * 1 gwei;
+uint256 public MIN_FEE = FULFILLMENT_GAS_LIMIT * 150 gwei;
 
 // A string used to allow having different salt than other contracts
 bytes32 public SALT_PREFIX = "my_demo_salt_change_me";


### PR DESCRIPTION
### Description

Corrects the randomness precompile gas in tutorial and precompile docs to adjust for Moonbeam gas price. 

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
