### PR TITLE
Split tracing and rpc endpoint providers up

### DIFF
--- a/builders/build/eth-api/debug-trace.md
+++ b/builders/build/eth-api/debug-trace.md
@@ -7,15 +7,17 @@ description:  Learn how to leverage Geth's Debug and Txpool APIs, and OpenEthere
 
 ![Debug & Trace Moonbeam Banner](/images/builders/build/eth-api/debug-trace/debug-trace-banner.png)
 
-## Introduction {: #introduction } 
+## Introduction {: #introduction }
 
 Geth's `debug` and `txpool` APIs and OpenEthereum's `trace` module provide non-standard RPC methods for getting a deeper insight into transaction processing. As part of Moonbeam's goal of providing a seamless Ethereum experience for developers, there is support for some of these non-standard RPC methods. Supporting these RPC methods is an important milestone because many projects, such as [The Graph](https://thegraph.com/){target=_blank} or [Blockscout](https://docs.blockscout.com/){target=_blank}, rely on them to index blockchain data.
+
+To view a list of tracing RPC providers, please check out the [Network Endpoints](/builders/get-started/endpoints#tracing-providers){target=_blank} page.
 
 This guide will cover the supported RPC methods available on Moonbeam as well as how to invoke the methods using curl commands against a local Moonbase Alpha tracing node.
 
 ## Supported RPC Methods {: #supported-rpc-methods }
 
-The following RPC methods are available: 
+The following RPC methods are available:
 
   - [`debug_traceTransaction`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debug_tracetransaction){target=_blank}
   - [`debug_traceBlockByNumber`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debug_traceblockbynumber){target=_blank}
@@ -25,7 +27,7 @@ The following RPC methods are available:
   - [`txpool_inspect`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_inspect){target=_blank}
   - [`txpool_status`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_status){target=_blank}
 
-## Debug API {: #geth-debug-api } 
+## Debug API {: #geth-debug-api }
 
 The debug RPC implementations follow [Geth's debug API guidelines](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug){target=_blank}:
 
@@ -44,10 +46,10 @@ As *optional* parameters for the supported debug methods, you can provide the fo
 The txpool RPC implementations follow [Geth's txpool API guidelines](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool):
 
   - **[`txpool_content`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_content){target=_blank}** - no required or optional parameters
-  - **[`txpool_inspect`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_inspect){target=_blank}** - no required or optional parameters 
+  - **[`txpool_inspect`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_inspect){target=_blank}** - no required or optional parameters
   - **[`txpool_status`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool_status){target=_blank}** - no required or optional parameters
 
-## Trace Module {: #trace-module } 
+## Trace Module {: #trace-module }
 
 The [`trace_filter`](https://openethereum.github.io/JSONRPC-trace-module#trace_filter){target=_blank} RPC implementation follows [OpenEthereum's trace module guidelines](https://openethereum.github.io/JSONRPC-trace-module){target=_blank}. The RPC method requires any of the following *optional* parameters:
 
@@ -67,7 +69,7 @@ To change the default values you can add [Additional Flags](/node-operators/netw
 
 ## Checking Prerequisites {: #checking-prerequisites }
 
-For this guide, you will need to have a locally running instance of a Moonbase Alpha tracing node with the `debug`, `txpool`, and `tracing` flags enabled for this guide. You can also adapt the instructions for Moonbeam and Moonriver. 
+For this guide, you will need to have a locally running instance of a Moonbase Alpha tracing node with the `debug`, `txpool`, and `tracing` flags enabled for this guide. You can also adapt the instructions for Moonbeam and Moonriver.
 
 If you haven't already done so, you can follow the guide on [Running a Tracing Node](/node-operators/networks/tracing-node/){target=_blank}. The RPC HTTP endpoint should be at `{{ networks.development.rpc_url }}`.
 
@@ -135,6 +137,6 @@ curl {{ networks.development.rpc_url }} -H "Content-Type:application/json;charse
   }'
 ```
 
-For this example, the `txpool_status` method will return the number of transactions currently pending or queued. 
+For this example, the `txpool_status` method will return the number of transactions currently pending or queued.
 
 ![Txpool Request and Response](/images/builders/build/eth-api/debug-trace/debug-trace-4.png)

--- a/builders/get-started/endpoints.md
+++ b/builders/get-started/endpoints.md
@@ -181,7 +181,7 @@ The following providers provide tracing RPC endpoints:
 
 ### OnFinality {: #onfinality-tracing }
 
-OnFinality's Trace API can be used to quickly get started tracing and debugging transactions on Moonbeam and Moonriver. It is only available to users on their [Growth and Ultimate plans](https://onfinality.io/pricing){target=_blank}.
+[OnFinality](https://onfinality.io/){target=_blank}'s Trace API can be used to quickly get started tracing and debugging transactions on Moonbeam and Moonriver. It is only available to users on their [Growth and Ultimate plans](https://onfinality.io/pricing){target=_blank}.
 
 To use the Trace API, you simply call the trace method of your choice from your [private RPC endpoint](#onfinality). For a list of the supported networks and trace methods, please check out [OnFinality's Trace API documentation](https://documentation.onfinality.io/support/trace-api#TraceAPI-SupportedNetworks){target=_blank}.
 

--- a/builders/get-started/endpoints.md
+++ b/builders/get-started/endpoints.md
@@ -9,11 +9,11 @@ description: Use one of the supported API providers to connect to a public endpo
 
 ## Public Endpoints {: #public-endpoints }
 
-Moonbeam-based networks have two endpoints available for users to connect to: one for HTTPS and one for WSS. 
+Moonbeam-based networks have two endpoints available for users to connect to: one for HTTPS and one for WSS.
 
 The endpoints in this section are for development purposes only and are not meant to be used in production applications.
 
-If you are looking for an API provider suitable for production use, you can check out the [Endpoint Providers](#endpoint-providers) section of this guide. 
+If you are looking for an API provider suitable for production use, you can check out the [Endpoint Providers](#endpoint-providers) section of this guide.
 
 ### Moonbeam {: #moonbeam }
 
@@ -27,7 +27,7 @@ If you are looking for an API provider suitable for production use, you can chec
 
 --8<-- 'text/endpoints/moonbase.md'
 
-## Endpoint Providers {: #endpoint-providers }
+## RPC Endpoint Providers {: #endpoint-providers }
 
 You can create your own endpoint suitable for development or production use using any of the following API providers:
 
@@ -61,7 +61,7 @@ To get started, you'll need to head to [Blast](https://blastapi.io/){target=_bla
 2. Click on **Available Endpoints**
 3. Select a network for your endpoint. There are three options to choose from: Moonbeam, Moonriver and Moonbase Alpha
 4. Confirm the selected network and Press **Activate**
-5. You'll now see your chosen network under **Active Endpoints**. Click on the network and you'll see your custom RPC and WSS endpoints on the next page 
+5. You'll now see your chosen network under **Active Endpoints**. Click on the network and you'll see your custom RPC and WSS endpoints on the next page
 
 ![Bware Labs](/images/builders/get-started/endpoints/endpoints-2.png)
 
@@ -73,7 +73,7 @@ To get started, you'll need to head to [BlockSpaces](https://www.blockspaces.com
 
 1. Visit [BlockSpaces](https://www.blockspaces.com/web3-infrastructure){target=_blank}
 2. Submit your **email**
-3. Copy Moonbeam/Moonriver endpoint to your clipboard 
+3. Copy Moonbeam/Moonriver endpoint to your clipboard
 
  ![BlockSpaces](/images/builders/get-started/endpoints/endpoints-3.png)
 
@@ -113,10 +113,6 @@ To create a custom OnFinality endpoint, go to [OnFinality](https://onfinality.io
 3. Your custom API endpoint will be generated automatically
 
 ![OnFinality](/images/builders/get-started/endpoints/endpoints-6.png)
-
-OnFinality also provides a Trace API, which allows you to call non-standard RPC methods that belong to Geth's `debug` and `txpool` APIs and OpenEthereum's `trace` module. Currently, the [Trace API is only supported on Moonriver](https://documentation.onfinality.io/support/trace-api#TraceAPI-SupportedNetworks){target=_blank}, with support for Moonbeam coming soon.
-
-If you are tracing historic blocks, it is recommended to use your own dedicated trace node to backfill any data, and then once you're caught up, you can switch to using the Trace API. You can check out the [How to Deploy a Trace Node for Moonbeam on OnFinality](https://onfinality.medium.com/how-to-deploy-a-trace-node-for-moonbeam-on-onfinality-85683181d290){target=-_blank} post for more information on how to get started.
 
 ### Pocket Network {: #pokt }
 
@@ -175,3 +171,18 @@ To get started, head to the [Ankr Protocol](https://www.ankr.com/protocol/){targ
 
 ![Ankr](/images/builders/get-started/endpoints/endpoints-5.png)-->
 
+## Tracing RPC Endpoint Providers {: #tracing-providers }
+
+Tracing RPC endpoints allow you to access non-standard RPC methods, such as those that belong to Geth's `debug` and `txpool` APIs and OpenEthereum's `trace` module. To see a list of the supported non-standard RPC methods on Moonbeam for debugging and tracing, please refer to the [Debug API & Trace Module](/builders/build/eth-api/debug-trace){target=_blank} guide.
+
+The following providers provide tracing RPC endpoints:
+
+- [OnFinality](#onfinality-tracing)
+
+### OnFinality {: #onfinality-tracing }
+
+OnFinality's Trace API can be used to quickly get started tracing and debugging transactions on Moonbeam and Moonriver. It is only available to users on their [Growth and Ultimate plans](https://onfinality.io/pricing){target=_blank}.
+
+To use the Trace API, you simply call the trace method of your choice from your [private RPC endpoint](#onfinality). For a list of the supported networks and trace methods, please check out [OnFinality's Trace API documentation](https://documentation.onfinality.io/support/trace-api#TraceAPI-SupportedNetworks){target=_blank}.
+
+Please note that if you are tracing historic blocks, it is recommended to use your own dedicated trace node to backfill any data, and then once you're caught up, you can switch to using the Trace API. You can check out the [How to Deploy a Trace Node for Moonbeam on OnFinality](https://onfinality.medium.com/how-to-deploy-a-trace-node-for-moonbeam-on-onfinality-85683181d290){target=-_blank} post for more information on how to spin up your own dedicated trace node.


### PR DESCRIPTION
### Description

This PR creates a new "Tracing RPC Endpoints" section. I kept the "Tracing RPC Endpoints" section in the same format as the "RPC Endpoints" section even though we only have OnFinality listed there. If it looks too silly let me know and I'll change it! 🙂 

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
