### PR TITLE
fix checking prereqs section of batch tutorial

### DIFF
--- a/tutorials/eth-api/batch-approve-swap.md
+++ b/tutorials/eth-api/batch-approve-swap.md
@@ -26,7 +26,7 @@ For this tutorial, you'll need the following:
 - An account with funds.
   --8<-- 'text/faucet/faucet-list-item.md'
 - An empty Hardhat project that is configured for the Moonbase Alpha TestNet. For step-by-step instructions, please refer to the [Creating a Hardhat Project](/builders/build/eth-api/dev-env/hardhat/#creating-a-hardhat-project){target=_blank} and the [Hardhat Configuration File](/builders/build/eth-api/dev-env/hardhat/#hardhat-configuration-file){target=_blank} sections of our Hardhat documentation page
--
+
 --8<-- 'text/common/endpoint-examples.md'
 
 ### Install Dependencies {: #install-dependencies }


### PR DESCRIPTION
### Description

Not sure why but the spacing caused the second bullet item to appear as a header. This PR fixes that
