### PR TITLE
add destinationFeeBalance property in the response examples

### DIFF
--- a/builders/interoperability/xcm/xcm-sdk/v1/xcm-sdk.md
+++ b/builders/interoperability/xcm/xcm-sdk/v1/xcm-sdk.md
@@ -329,6 +329,13 @@ As previously mentioned, regardless of which method you use to build the transfe
           weight: 1000000000,
           ws: 'wss://rpc.polkadot.io'
         },
+        destinationFeeBalance: e {
+          key: 'dot',
+          originSymbol: 'DOT',
+          amount: 0n,
+          decimals: 10,
+          symbol: 'DOT'
+        },
         existentialDeposit: e {
           key: 'dot',
           originSymbol: 'DOT',
@@ -437,6 +444,13 @@ The `swap` function returns the transfer data with the original source chain and
           ss58Format: 0,
           weight: 1000000000,
           ws: 'wss://rpc.polkadot.io'
+        },
+        destinationFeeBalance: e {
+          key: 'dot',
+          originSymbol: 'DOT',
+          amount: 0n,
+          decimals: 10,
+          symbol: 'DOT'
         },
         existentialDeposit: e {
           key: 'dot',


### PR DESCRIPTION
### Description

After the new changes deployed to the XCM-SDK, in which we return a new property `destinationFeeBalance`, we have to add the property in the example responses in the docs

The property  `destinationFeeBalance` is useful when the asset paying for the fees in the destination chain is different from the asset being transferred and/or the asset paying for the fees in the source chain.

Example: sending WBTC from HydraDX to Moonbeam:
- asset transferred: WBTC
- pays for fees in HydraDX: HDX
- pays for fees in Moonbeam: GLMR

The property `destinationFeeBalance` helps controlling that the sender has enough GLMR in their HydraDX account.

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [x] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [x] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
   - [x] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [x] If images have been added, I have run the `compress-images.py` script to compress the images.
- [x] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [x] If this page requires a disclaimer, I have added one

### Corresponding PRs

https://github.com/PureStake/xcm-sdk/pull/127

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
