### PR TITLE
update links and remove mrl banner image

### DIFF
--- a/builders/interoperability/mrl.md
+++ b/builders/interoperability/mrl.md
@@ -5,14 +5,12 @@ description: Learn how to receive Moonbeam Routed Liquidity after establishing a
 
 # Moonbeam Routed Liquidity
 
-![XCM Overview Banner](/images/builders/interoperability/xcm/xc-integration/xc-integration-banner.png)
-
 ## Introduction {: #introduction }
 
 Moonbeam Routed Liquidity (MRL) refers to a Moonbeam use case in which liquidity in any blockchain ecosystem that Moonbeam is connected to can be routed to Polkadot parachains. This is possible because of multiple components that work together:
 
 - **General Message Passing (GMP)** - technology connecting multiple blockchains together, including Moonbeam. With it, developers can pass messages with arbitrary data, and tokens can be sent across non-parachain blockchains through [chain-agnostic GMP protocols](/builders/interoperability/protocols){target=_blank}
-- [**Cross-Consensus Message Passing (XCM)**](builders/interoperability/xcm/overview/){target=_blank} - Polkadot's flavor of GMP. Main technology driving cross-chain interactions between Polkadot and its parachains, including Moonbeam
+- [**Cross-Consensus Message Passing (XCM)**](/builders/interoperability/xcm/overview/){target=_blank} - Polkadot's flavor of GMP. Main technology driving cross-chain interactions between Polkadot and its parachains, including Moonbeam
 - **XCM-Enabled ERC-20s** - also referred to as [local XC-20s](/builders/interoperability/xcm/xc20/overview/#local-xc20s){target=_blank}, are all of the ERC-20 tokens that exist on Moonbeam's EVM that are XCM-enabled out of the box
 - [**GMP Precompile**](/builders/pallets-precompiles/precompiles/gmp/){target=_blank} - a [precompiled contract](/builders/pallets-precompiles/precompiles/overview/){target=_blank} that acts as an interface between a message passed from [Wormhole GMP protocol](/builders/interoperability/protocols/wormhole/){target=_blank} and XCM
 

--- a/builders/interoperability/xcm/xc-registration/assets.md
+++ b/builders/interoperability/xcm/xc-registration/assets.md
@@ -27,7 +27,7 @@ Registering External XC-20s on Moonbeam is a multi-step process that, at a high 
 
 If a channel between Moonbeam and the origin chain of the asset does not yet exist, one will need to be opened. You can batch the channel-related calls with the asset registration calls, so you only need to submit a single proposal. You'll need to start by creating a couple of forum posts: an [XCM Disclosure](/builders/interoperability/xcm/xc-registration/forum-templates#xcm-disclosures){target=_blank} post and an [XCM Proposal](/builders/interoperability/xcm/xc-registration/forum-templates#xcm-proposals){target=_blank} post.
 
-After you've collected feedback from community members, you can create a proposal to open a channel and register any assets. Please refer to the [Establishing an XC Integration with Moonbeam](/builders/interoperability/xcm/xc-integration/){target=_blank} guide for more information on opening a channel.
+After you've collected feedback from community members, you can create a proposal to open a channel and register any assets. Please refer to the [Establishing an XC Integration with Moonbeam](/builders/interoperability/xcm/xc-registration/xc-integration){target=_blank} guide for more information on opening a channel.
 
 ![Asset registration if XC channel doesn't exist](/images/builders/interoperability/xcm/xc-registration/assets/assets-1.png)
 
@@ -266,7 +266,7 @@ If you need DEV tokens (the native token for Moonbase Alpha) to use your XC-20 a
 
 In order to enable cross-chain transfers of Moonbeam assets, including Moonbeam native assets (GLMR, MOVR, DEV) and local XC-20s (XCM-enabled ERC-20s) deployed on Moonbeam, between Moonbeam and another chain, you'll need to register the assets on the other chain. Since each chain stores cross-chain assets differently, the exact steps to register Moonbeam assets on another chain will vary depending on the chain. At the very least, you'll need to know the metadata and the multilocation of the assets on Moonbeam.
 
-There are additional steps aside from asset registration that will need to be taken to enable cross-chain integration with Moonbeam. For more information, please refer to the [Establishing an XC Integration with Moonbeam](/builders/interoperability/xcm/xc-integration){target=_blank} guide.
+There are additional steps aside from asset registration that will need to be taken to enable cross-chain integration with Moonbeam. For more information, please refer to the [Establishing an XC Integration with Moonbeam](/builders/interoperability/xcm/xc-registration/xc-integration){target=_blank} guide.
 
 ### Register Moonbeam Native Assets on Another Chain {: #register-moonbeam-native-assets }
 

--- a/learn/features/governance.md
+++ b/learn/features/governance.md
@@ -298,8 +298,8 @@ The OpenGov Technical Committee is made up of members of the community who have 
 
 For related guides on submitting and voting on referenda on Moonbeam with OpenGov, please check the following guides:
 
- - [How to Submit a Proposal](/tokens/governance/proposals/opengov-proposals){target=_blank}
- - [How to Vote on a Proposal](/tokens/governance/voting/opengov-voting){target=_blank}
+ - [How to Submit a Proposal](/tokens/governance/proposals){target=_blank}
+ - [How to Vote on a Proposal](/tokens/governance/voting){target=_blank}
  - [Interact with the Preimages Precompiled Contract (Solidity Interface)](/builders/pallets-precompiles/precompiles/preimage/){target=_blank}
  - [Interact with the Referenda Precompiled Contract (Solidity Interface)](/builders/pallets-precompiles/precompiles/referenda/){target=_blank}
  - [Interact with the Conviction Voting Precompiled Contract (Solidity Interface)](/builders/pallets-precompiles/precompiles/conviction-voting/){target=_blank}

--- a/tokens/governance/proposals.md
+++ b/tokens/governance/proposals.md
@@ -13,7 +13,7 @@ A proposal is a submission to the chain in which a token holder suggests for an 
 
 In Moonbeam, users are able to create and vote on proposals using their H160 address and private key, that is, their regular Ethereum account!
 
-This guide will outline the process, with step-by-step instructions, of how to submit a proposal for other token holders to vote on in OpenGov (Governance v2). This guide will show you how to submit the proposal on Moonbase Alpha, but it can be easily adapted for Moonbeam and Moonriver. There is a separate guide on [How to Vote on a Proposal in OpenGov](/tokens/governance/voting/opengov-voting){target=_blank}.
+This guide will outline the process, with step-by-step instructions, of how to submit a proposal for other token holders to vote on in OpenGov (Governance v2). This guide will show you how to submit the proposal on Moonbase Alpha, but it can be easily adapted for Moonbeam and Moonriver. There is a separate guide on [How to Vote on a Proposal in OpenGov](/tokens/governance/voting){target=_blank}.
 
 For more information on Moonbeam's governance system, please refer to the [Governance on Moonbeam](/learn/features/governance/){target=_blank} overview page.
 
@@ -126,4 +126,4 @@ If you login to [Polkassembly](https://moonbeam.polkassembly.io/opengov){target=
 
 The proposal is now in the Lead-in Period and is ready to be voted on! In order for your proposal to progress out of the Lead-in Period to the next phase, at a minimum the Prepare Period will need to pass so there is enough time for the proposal to be discussed, there will need to be enough Capacity in the chosen Track, and the Decision Deposit will need to be submitted. The deposit can be paid by any token holder. If there isn't enough Capacity or the Decision Deposit hasn't been submitted, but the Prepare Period has passed, the proposal will remain in the Lead-in Period until all of the criteria is met.
 
-To learn how to vote on a proposal, please refer to the [How to Vote on a Proposal in OpenGov](/tokens/governance/voting/opengov-voting){target=_blank} guide.
+To learn how to vote on a proposal, please refer to the [How to Vote on a Proposal in OpenGov](/tokens/governance/voting){target=_blank} guide.


### PR DESCRIPTION
### Description

- The banner used for the MRL page was deleted in a separate PR and so it resulted in a 404. Just deleted the reference to the banner since it's being removed with the docs redesign anyway
- Fix 404 link
- Fix meta refresh redirects

### Corresponding PRs

https://github.com/moonbeam-foundation/moonbeam-docs-cn/pull/329