### PR TITLE
update the gmp precompile as it now accepts a v2 user versioned action

### DIFF
--- a/.snippets/code/precompiles/gmp/v1-payload.ts
+++ b/.snippets/code/precompiles/gmp/v1-payload.ts
@@ -1,0 +1,72 @@
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
+enum MRLTypes {
+  // Runtime defined MultiLocation. Allows for XCM versions 2 and 3
+  XcmVersionedMultiLocation = 'XcmVersionedMultiLocation',
+  // MRL payload (V1) that only defines the destination MultiLocation
+  XcmRoutingUserAction = 'XcmRoutingUserAction',
+  // Wrapper object for the MRL payload
+  VersionedUserAction = 'VersionedUserAction',
+}
+
+// Parachain IDs of each parachain
+enum Parachain {
+  MoonbaseBeta = 888,
+  // Insert additional parachain IDs
+}
+
+// List of parachains that use ethereum (20) accounts
+const ETHEREUM_ACCOUNT_PARACHAINS = [Parachain.MoonbaseBeta];
+
+// A function that creates a SCALE encoded payload to use with transferTokensWithPayload
+async function createMRLPayload(
+  parachainId: Parachain,
+  account: string
+): Promise<Uint8Array> {
+  // Create a multilocation object based on the target parachain's account type
+  const isEthereumStyle = ETHEREUM_ACCOUNT_PARACHAINS.includes(parachainId);
+  const multilocation = {
+    V3: {
+      parents: 1,
+      interior: {
+        X2: [
+          { Parachain: parachainId },
+          isEthereumStyle
+            ? { AccountKey20: { key: account } }
+            : { AccountId32: { id: account } },
+        ],
+      },
+    },
+  };
+
+  // Creates an API for Moonbeam that defines MRL's special types
+  const wsProvider = new WsProvider('wss://wss.api.moonbase.moonbeam.network');
+  const api = await ApiPromise.create({
+    provider: wsProvider,
+    types: {
+      [MRLTypes.XcmRoutingUserAction]: {
+        destination: MRLTypes.XcmVersionedMultiLocation,
+      },
+      [MRLTypes.VersionedUserAction]: {
+        _enum: { V1: MRLTypes.XcmRoutingUserAction },
+      },
+    },
+  });
+
+  // Format multilocation object as a Polkadot.js type
+  const versionedMultilocation = api.createType(
+    MRLTypes.XcmVersionedMultiLocation,
+    multilocation
+  );
+  const userAction = api.createType(MRLTypes.XcmRoutingUserAction, {
+    destination: versionedMultilocation,
+  });
+
+  // Wrap and format the MultiLocation object into the precompile's input type
+  const versionedUserAction = api.createType(MRLTypes.VersionedUserAction, {
+    V1: userAction,
+  });
+
+  // SCALE encode resultant precompile formatted objects
+  return versionedUserAction.toU8a();
+}

--- a/.snippets/code/precompiles/gmp/v2-payload.ts
+++ b/.snippets/code/precompiles/gmp/v2-payload.ts
@@ -1,0 +1,79 @@
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { u256 } from '@polkadot/types';
+
+enum MRLTypes {
+  // Runtime defined MultiLocation. Allows for XCM versions 2 and 3
+  XcmVersionedMultiLocation = 'XcmVersionedMultiLocation',
+  // MRL payload (V2) that defines the destination MultiLocation and a 
+  // fee for the relayer
+  XcmRoutingUserActionWithFee = 'XcmRoutingUserActionWithFee',
+  // Wrapper object for the MRL payload
+  VersionedUserAction = 'VersionedUserAction',
+}
+
+// Parachain IDs of each parachain
+enum Parachain {
+  MoonbaseBeta = 888,
+  // Insert additional parachain IDs
+}
+
+// List of parachains that use ethereum (20) accounts
+const ETHEREUM_ACCOUNT_PARACHAINS = [Parachain.MoonbaseBeta];
+
+// A function that creates a SCALE encoded payload to use with 
+// transferTokensWithPayload
+async function createMRLPayload(
+  parachainId: Parachain,
+  account: string,
+  fee: u256
+): Promise<Uint8Array> {
+  // Create a multilocation object based on the target parachain's account
+  // type
+  const isEthereumStyle = ETHEREUM_ACCOUNT_PARACHAINS.includes(parachainId);
+  const multilocation = {
+    V3: {
+      parents: 1,
+      interior: {
+        X2: [
+          { Parachain: parachainId },
+          isEthereumStyle
+            ? { AccountKey20: { key: account } }
+            : { AccountId32: { id: account } },
+        ],
+      },
+    },
+  };
+
+  // Creates an API for Moonbeam that defines MRL's special types
+  const wsProvider = new WsProvider('wss://wss.api.moonbase.moonbeam.network');
+  const api = await ApiPromise.create({
+    provider: wsProvider,
+    types: {
+      [MRLTypes.XcmRoutingUserActionWithFee]: {
+        destination: MRLTypes.XcmVersionedMultiLocation,
+        fee: 'U256',
+      },
+      [MRLTypes.VersionedUserAction]: {
+        _enum: { V2: MRLTypes.XcmRoutingUserActionWithFee },
+      },
+    },
+  });
+
+  // Format multilocation object as a Polkadot.js type
+  const versionedMultilocation = api.createType(
+    MRLTypes.XcmVersionedMultiLocation,
+    multilocation
+  );
+  const userAction = api.createType(MRLTypes.XcmRoutingUserActionWithFee, {
+    destination: versionedMultilocation,
+    fee,
+  });
+
+  // Wrap and format the MultiLocation object into the precompile's input type
+  const versionedUserAction = api.createType(MRLTypes.VersionedUserAction, {
+    V2: userAction,
+  });
+
+  // SCALE encode resultant precompile formatted objects
+  return versionedUserAction.toU8a();
+}

--- a/builders/pallets-precompiles/precompiles/gmp.md
+++ b/builders/pallets-precompiles/precompiles/gmp.md
@@ -222,6 +222,6 @@ The GMP precompile is currently in its early stages. There are many restrictions
 
 - There is currently no fee mechanism. Relayers that run the forwarding of liquidity on Moonbeam to a parachain will be subsidizing transactions. This may change in the future
 - The precompile does not check to ensure that the destination chain supports the token that is being sent to it. **Incorrect multilocations may result in loss of funds**
-- Errors in constructing a multilocation will result in reverts, which will trap tokens and a loss of funds
+- Errors in constructing a multilocation will result in reverts, which will trap tokens and result in a loss of funds
 - There is currently no recommended path backwards, from parachains to other chains like Ethereum. There is additional protocol level work that must be done before a one-click method can be realized
   - Due to a restriction with the ERC-20 XC-assets, the only way to send tokens from a parachain back through Moonbeam is to have xcGLMR on the origin parachain and use it as a fee asset when sending tokens back  

--- a/builders/pallets-precompiles/precompiles/gmp.md
+++ b/builders/pallets-precompiles/precompiles/gmp.md
@@ -87,7 +87,7 @@ The following multilocation templates target accounts on other parachains with M
 === "AccountKey20"
 
     ```js
-    v1: {
+    {
       parents: 1,
       interior: {
         X2: [


### PR DESCRIPTION
### Description

As of Runtime 2500, a new fee mechanism has been added for the GMP precompile, which is implemented in the V2 VersionedUserAction. This PR updates the GMP precompile page and snippet for creating a V2 payload.

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
