### PR TITLE
add section on overriding local xc-20 transfer gas limits

### DIFF
--- a/builders/interoperability/xcm/xc20/xtokens.md
+++ b/builders/interoperability/xcm/xc20/xtokens.md
@@ -323,8 +323,10 @@ const asset = {
             { AccountKey20: { key: 'INSERT_ERC_20_ADDRESS' } },
             { 
               // gas_limit: 300000 (zero-padded)
-              GeneralKey:
-                '0x6761735f6c696d69743ae0930400000000000000000000000000000000000000'
+              GeneralKey: {
+                data: '0x6761735f6c696d69743ae0930400000000000000000000000000000000000000',
+                length: 32,
+              },
             },
           ],
         },

--- a/builders/interoperability/xcm/xc20/xtokens.md
+++ b/builders/interoperability/xcm/xc20/xtokens.md
@@ -182,7 +182,7 @@ Now that you have the values for each of the parameters, you can write the scrip
 
 Once the transaction is processed, the target account on the relay chain should have received the transferred amount minus a small fee that is deducted to execute the XCM on the destination chain.
 
-### X-Tokens Transfer MultiAsset Function {: #xtokens-transfer-multiasset-function}
+### X-Tokens Transfer Multiasset Function {: #xtokens-transfer-multiasset-function}
 
 In this example, you'll build an XCM message to transfer xcUNIT from Moonbase Alpha back to its relay chain using the `transferMultiasset` function of the X-Tokens Pallet.
 

--- a/builders/interoperability/xcm/xc20/xtokens.md
+++ b/builders/interoperability/xcm/xc20/xtokens.md
@@ -322,15 +322,9 @@ const asset = {
             { PalletInstance: 48 },
             { AccountKey20: { key: 'INSERT_ERC_20_ADDRESS' } },
             { 
-              GeneralKey: {
-                // The byte array represents: 
-                // 'gas_limit:' + 300000 (little endian) + zeros padding
-                data: [
-                  103, 97, 115, 95, 108, 105, 109, 105, 116, 58, 224, 147, 4, 0,
-                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                ],
-                length: 32,
-              },
+              // gas_limit: 300000 (zero-padded)
+              GeneralKey:
+                '0x6761735f6c696d69743ae0930400000000000000000000000000000000000000'
             },
           ],
         },


### PR DESCRIPTION
### Description

This PR adds a new section to the X-Tokens page on overriding the default gas limits for local xc-20 transfers.

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
