### PR TITLE
Allow viem client as EVM signer in xcm-sdk

### DIFF
--- a/builders/interoperability/xcm/xcm-sdk/v1/reference.md
+++ b/builders/interoperability/xcm/xcm-sdk/v1/reference.md
@@ -129,7 +129,7 @@ The SDK provides the following core methods:
     ??? code "Parameters"
         |    Name    |     Type     |                         Description                         |
         |:----------:|:------------:|:-----------------------------------------------------------:|
-        | `options?` | *SdkOptions* | Allows you to specify an `ethersSigner` or `polkadotSigner` |
+        | `options?` | *SdkOptions* | Allows you to specify an `evmSigner` or `polkadotSigner` |
 
     ??? code "Returns"
         |       Name        |   Type   |                                                        Description                                                         |
@@ -144,7 +144,7 @@ The SDK provides the following core methods:
         |:-----------------------:|:--------------------------------:|:--------------------------------------------------------------------------------------:|
         |  `destinationAddress`   |             *string*             |             The address of the receiving account on the destination chain              |
         | `destinationKeyorChain` |       *string \| AnyChain*       |                   The key or `Chain` data for the destination chain                    |
-        |     `ethersSigner?`     |          *EthersSigner*          | The Ethers signer for Ethereum-compatible chains that use H160 Ethereum-style accounts |
+        |     `evmSigner?`     |          *EthersSigner | WalletClient*          | The signer for Ethereum-compatible chains that use H160 Ethereum-style accounts. Can be either an ethers Signer or a viem WalletClient |
         |      `keyOrAsset`       |        *string \| Asset*         |                The key or `Asset` data for the asset being transferred                 |
         |    `polkadotSigner?`    | *PolkadotSigner \| IKeyringPair* |                          The Polkadot signer or Keyring pair                           |
         |     `sourceAddress`     |             *string*             |                 The address of the sending account on the source chain                 |

--- a/builders/interoperability/xcm/xcm-sdk/v1/reference.md
+++ b/builders/interoperability/xcm/xcm-sdk/v1/reference.md
@@ -144,7 +144,7 @@ The SDK provides the following core methods:
         |:-----------------------:|:--------------------------------:|:--------------------------------------------------------------------------------------:|
         |  `destinationAddress`   |             *string*             |             The address of the receiving account on the destination chain              |
         | `destinationKeyorChain` |       *string \| AnyChain*       |                   The key or `Chain` data for the destination chain                    |
-        |     `evmSigner?`     |          *EthersSigner | WalletClient*          | The signer for Ethereum-compatible chains that use H160 Ethereum-style accounts. Can be either an ethers Signer or a viem WalletClient |
+        |     `evmSigner?`     |          *EthersSigner | WalletClient*          | The signer for Ethereum-compatible chains that use H160 Ethereum-style accounts. Can be either an Ethers Signer or a viem WalletClient |
         |      `keyOrAsset`       |        *string \| Asset*         |                The key or `Asset` data for the asset being transferred                 |
         |    `polkadotSigner?`    | *PolkadotSigner \| IKeyringPair* |                          The Polkadot signer or Keyring pair                           |
         |     `sourceAddress`     |             *string*             |                 The address of the sending account on the source chain                 |

--- a/builders/interoperability/xcm/xcm-sdk/v1/xcm-sdk.md
+++ b/builders/interoperability/xcm/xcm-sdk/v1/xcm-sdk.md
@@ -33,16 +33,16 @@ npm install ethers@^5.7.2 @polkadot/api @polkadot/util-crypto
 
 ## Create Signers {: #create-signers }
 
-When transferring assets between chains, you'll need signers in place to sign the transactions. If you're interacting with an Ethereum-compatible chain that uses standard Ethereum-style H160 addresses, such as Moonbeam, you'll need to have an Ethereum signer, more specifically an [Ethers.js](https://docs.ethers.org/v5/){target=_blank} signer. To interact with the relay chain or other parachains, you'll need a [Polkadot](https://polkadot.js.org/docs/api/){target=_blank} signer.
+When transferring assets between chains, you'll need signers in place to sign the transactions. If you're interacting with an Ethereum-compatible chain that uses standard Ethereum-style H160 addresses, such as Moonbeam, you'll need to have an Ethereum signer, which can be an [Ethers.js](https://docs.ethers.org/v5/){target=_blank} signer, or a [viem Wallet Client](https://viem.sh/docs/clients/wallet.html){target=_blank}. To interact with the relay chain or other parachains, you'll need a [Polkadot](https://polkadot.js.org/docs/api/){target=_blank} signer.
 
 You can pass, for example, a [MetaMask signer into Ethers](https://docs.ethers.org/v5/getting-started/#getting-started--connecting){target=_blank} or another compatible wallet. Similarly, with Polkadot, you can [pass a compatible wallet to the signer using the `@polkadot/extension-dapp` library](https://polkadot.js.org/docs/extension/){target=_blank}.
 
-To create a signer for Ethers.js and Polkadot.js, you can refer to the following sections.
+To create a signer for EVM and Polkadot.js, you can refer to the following sections.
 
 !!! remember
     **Never store your private key or mnemonic in a JavaScript or TypeScript file.**
 
-### Create a Ethers Signer {: #create-a-ethers-signer }
+### Create a EVM Signer {: #create-a-evm-signer }
 
 To create a Ethers signer, you can use the following code snippet:
 
@@ -105,6 +105,44 @@ For Moonbeam specifically, you can use the following configurations:
       }
     );
     const ethersSigner = new ethers.Wallet(privateKey, provider);
+    ```
+
+Alternatively, you can create a viem Wallet Client to pass as EVM Signer
+
+=== "Moonbeam"
+
+    ```js
+    import { createWalletClient, custom } from 'viem'
+    import { moonbeam } from 'viem/chains'
+
+    const client = createWalletClient({
+      chain: moonbeam,
+      transport: custom(window.ethereum)
+    })
+    ```
+
+=== "Moonriver"
+
+    ```js
+    import { createWalletClient, custom } from 'viem'
+    import { moonriver } from 'viem/chains'
+
+    const client = createWalletClient({
+      chain: moonriver,
+      transport: custom(window.ethereum)
+    })
+    ```
+
+=== "Moonbase Alpha"
+
+    ```js
+    import { createWalletClient, custom } from 'viem'
+    import { moonbase } from 'viem/chains'
+
+    const client = createWalletClient({
+      chain: moonbase,
+      transport: custom(window.ethereum)
+    })
     ```
 
 !!! note
@@ -206,7 +244,7 @@ const fromPolkadot = async() => {
     .asset('dot')
     .source('polkadot')
     .destination('moonbeam')
-    .accounts(pair.address, ethersSigner.address {
+    .accounts(pair.address, evmSigner.address {
       pair,
     });
 }
@@ -224,7 +262,7 @@ import { Sdk } from '@moonbeam-network/xcm-sdk';
 
 const fromPolkadot = async() => {
   const data = await Sdk().getTransferData({
-    destinationAddress: ethersSigner.address,
+    destinationAddress: evmSigner.address,
     destinationKeyOrChain: 'moonbeam',
     keyOrAsset: 'dot',
     polkadotSigner: pair,


### PR DESCRIPTION
### Description

With the latest xcm-sdk version, we allow `viem`'s [WalletClient](https://viem.sh/docs/clients/wallet.html) as a signer. Since there is an ongoing tendency for replacing `ethers` for `viem`

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [x] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [x] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [x] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [x] If images have been added, I have run the `compress-images.py` script to compress the images.
- [x] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [x] If this page requires a disclaimer, I have added one

### Corresponding PRs

https://github.com/PureStake/xcm-sdk/pull/131

### After Translation Requirements

- [x] Will need to create PR in `moonbeam-docs` repo to remove images
- [x] Will need to create PR in `moonbeam-docs` repo to remove variables
- [x] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

n/a
