### PR TITLE
Minor Hardhat Updates

### DIFF
--- a/builders/build/eth-api/dev-env/foundry.md
+++ b/builders/build/eth-api/dev-env/foundry.md
@@ -416,7 +416,7 @@ To convert your preexisting Foundry project to a hybrid project, you will essent
 ```bash
 npm init
 npm install --save-dev hardhat @nomicfoundation/hardhat-foundry
-npx hardhat
+npx hardhat init
 ```
 
 For more information, please refer to our documentation on [Creating a Hardhat Project](/builders/build/eth-api/dev-env/hardhat/#creating-a-hardhat-project){target=_blank}.

--- a/builders/build/eth-api/dev-env/hardhat.md
+++ b/builders/build/eth-api/dev-env/hardhat.md
@@ -46,7 +46,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 4. Create a project
 
     ```sh
-    npx hardhat
+    npx hardhat init
     ```
 
     !!! note
@@ -82,6 +82,7 @@ Open the file and add the following contract to it:
 
 ```solidity
 // contracts/Box.sol
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.1;
 
 contract Box {

--- a/tutorials/eth-api/hardhat-start-to-end.md
+++ b/tutorials/eth-api/hardhat-start-to-end.md
@@ -51,7 +51,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 4. Create a project
 
     ```bash
-    npx hardhat
+    npx hardhat init
     ```
 
     !!! note


### PR DESCRIPTION
### Description

- `npx hardhat` is deprecated and should be replaced with `npx hardhat init` 
- I also noticed a missing license identifier so I added that. 

### Corresponding PRs

CN: https://github.com/moonbeam-foundation/moonbeam-docs-cn/pull/342