### PR TITLE
XCM Transactor & Chopsticks Fixes

### DIFF
--- a/builders/build/substrate-api/chopsticks.md
+++ b/builders/build/substrate-api/chopsticks.md
@@ -156,7 +156,7 @@ You can use a raw GitHub URL of the default configuration files, a path to a loc
 A configuration file is not necessary, however. All of the settings (except `genesis` and `timestamp`) can also be passed as flags to configure the environment completely in the command line. For example, the following command forks Moonbase Alpha at block 100.
 
 ```bash
-npx @acala-network/chopsticks@latest --endpoint {{ networks.moonbase.rpc_url }} --block 100
+npx @acala-network/chopsticks@latest --endpoint {{ networks.moonbase.wss_url }} --block 100
 ```
 
 ### Quickstart {: #quickstart }

--- a/builders/build/substrate-api/chopsticks.md
+++ b/builders/build/substrate-api/chopsticks.md
@@ -22,7 +22,7 @@ npm i @acala-network/chopsticks@latest
 Once installed, you can run commands with the Node package executor. For example, this runs Chopstick's base command:  
 
 ```bash
-npx @acala-network/chopsticks
+npx @acala-network/chopsticks@latest
 ```
 
 To run Chopsticks, you will need some sort of configuration, typically through a file. Chopsticks' source repository includes a set of [YAML](https://yaml.org/){target=_blank} configuration files that can be used to create a local copy of a variety of Substrate chains. You can download the configuration files from the [source repository's `configs` folder](https://github.com/AcalaNetwork/chopsticks.git){target=_blank}.  
@@ -127,27 +127,27 @@ These are the settings that can be included in the config file:
 |           `html`           |                           Include to generate storage diff preview between blocks.                           |
 |   `mock-signature-host`    | Mock signature host so that any signature starts with `0xdeadbeef` and filled by `0xcd` is considered valid. |
 
-You can use the configuration file with the base command `npx @acala-network/chopsticks` to fork assets by providing it with the `--config` flag.  
+You can use the configuration file with the base command `npx @acala-network/chopsticks@latest` to fork assets by providing it with the `--config` flag.  
 
 You can use a raw GitHub URL of the default configuration files, a path to a local configuration file, or simply use the chain's name for the `--config` flag. For example, the following commands all use Moonbeam's configuration in the same way:  
 
 === "Chain Name"
 
     ```bash
-    npx @acala-network/chopsticks --config=moonbeam
+    npx @acala-network/chopsticks@latest --config=moonbeam
     ```
 
 === "GitHub URL"
 
     ```bash
-    npx @acala-network/chopsticks \
+    npx @acala-network/chopsticks@latest \
     --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml
     ```
 
 === "Local File Path"
 
     ```bash
-    npx @acala-network/chopsticks --config=configs/moonbeam.yml
+    npx @acala-network/chopsticks@latest --config=configs/moonbeam.yml
     ```
 
 !!! note
@@ -156,7 +156,7 @@ You can use a raw GitHub URL of the default configuration files, a path to a loc
 A configuration file is not necessary, however. All of the settings (except `genesis` and `timestamp`) can also be passed as flags to configure the environment completely in the command line. For example, the following command forks Moonbase Alpha at block 100.
 
 ```bash
-npx @acala-network/chopsticks --endpoint {{ networks.moonbase.rpc_url }} --block 100
+npx @acala-network/chopsticks@latest --endpoint {{ networks.moonbase.rpc_url }} --block 100
 ```
 
 ### Quickstart {: #quickstart }
@@ -166,21 +166,21 @@ The simplest way to fork Moonbeam is through the configuration files that are st
 === "Moonbeam"
 
     ```bash
-    npx @acala-network/chopsticks \
+    npx @acala-network/chopsticks@latest \
     --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml
     ```
 
 === "Moonriver"
 
     ```bash
-    npx @acala-network/chopsticks \
+    npx @acala-network/chopsticks@latest \
     --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonriver.yml
     ```
 
 === "Moonbase Alpha"
 
     ```bash
-    npx @acala-network/chopsticks \
+    npx @acala-network/chopsticks@latest \
     --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbase-alpha.yml
     ```
 
@@ -211,7 +211,7 @@ You should now be able to interact with the fork as you would an active parachai
 
 ## Replaying Blocks {: #replaying-blocks }
 
-In the case where you would like to replay a block and retrieve its information to dissect the effects of an extrinsic, you can use the `npx @acala-network/chopsticks run-block` command. Its following flags are:  
+In the case where you would like to replay a block and retrieve its information to dissect the effects of an extrinsic, you can use the `npx @acala-network/chopsticks@latest run-block` command. Its following flags are:  
 
 |            Flag            |                                      Description                                       |
 |:--------------------------:|:--------------------------------------------------------------------------------------:|
@@ -227,7 +227,7 @@ In the case where you would like to replay a block and retrieve its information 
 For example, running the following command will re-run Moonbeam's block 1000, and write the storage diff and other data in a `moonbeam-output.json` file:  
 
 ```bash
-npx @acala-network/chopsticks run-block  \
+npx @acala-network/chopsticks@latest run-block  \
 --endpoint wss://wss.api.moonbeam.network  \
 --output-path=./moonbeam-output.json  \
 --block 1000
@@ -238,7 +238,7 @@ npx @acala-network/chopsticks run-block  \
 To test out XCM messages between networks, you can fork multiple parachains and a relay chain locally. For example, the following will fork Moonriver, Karura, and Kusama given that you've downloaded the [`configs` directory from the source GitHub repository](https://github.com/AcalaNetwork/chopsticks/tree/master/configs){target=_blank}:  
 
 ```bash
-npx @acala-network/chopsticks xcm \
+npx @acala-network/chopsticks@latest xcm \
 --r=kusama.yml \
 --p=moonriver.yml \
 --p=karura.yml

--- a/builders/integrations/indexers/subsquid.md
+++ b/builders/integrations/indexers/subsquid.md
@@ -65,7 +65,7 @@ To get started indexing Substrate data on Moonbeam, you'll need to create a Subs
         ```ts
         const processor = new SubstrateBatchProcessor();
         processor.setDataSource({
-          chain: {{ networks.moonbeam.rpc_url }},
+          chain: '{{ networks.moonbeam.rpc_url }}',
           // Resolves to 'https://moonbeam.archive.subsquid.io'
           archive: lookupArchive('moonbeam', { type: 'Substrate' }),
         });
@@ -76,7 +76,7 @@ To get started indexing Substrate data on Moonbeam, you'll need to create a Subs
         ```ts
         const processor = new SubstrateBatchProcessor();
         processor.setDataSource({
-          chain: {{ networks.moonriver.rpc_url }},
+          chain: '{{ networks.moonriver.rpc_url }}',
           // Resolves to 'https://moonriver.archive.subsquid.io'
           archive: lookupArchive('moonriver', { type: 'Substrate' }),
         });
@@ -87,7 +87,7 @@ To get started indexing Substrate data on Moonbeam, you'll need to create a Subs
         ```ts
         const processor = new SubstrateBatchProcessor();
         processor.setDataSource({
-          chain: {{ networks.moonbase.rpc_url }},
+          chain: '{{ networks.moonbase.rpc_url }}',
           // Resolves to 'https://moonbase.archive.subsquid.io'
           archive: lookupArchive('moonbase', { type: 'Substrate' }),
         });
@@ -145,7 +145,7 @@ To get started indexing EVM data on Moonbeam, you'll need to create a Subsquid p
         ```ts
         const processor = new EvmBatchProcessor();
         processor.setDataSource({
-          chain: {{ networks.moonbeam.rpc_url }},
+          chain: '{{ networks.moonbeam.rpc_url }}',
           // Resolves to 'https://moonbeam-evm.archive.subsquid.io'
           archive: lookupArchive('moonbeam', { type: 'EVM' })
         });
@@ -156,7 +156,7 @@ To get started indexing EVM data on Moonbeam, you'll need to create a Subsquid p
         ```ts
         const processor = new EvmBatchProcessor();
         processor.setDataSource({
-          chain: {{ networks.moonriver.rpc_url }},
+          chain: '{{ networks.moonriver.rpc_url }}',
           // Resolves to 'https://moonriver-evm.archive.subsquid.io'
           archive: lookupArchive('moonriver', { type: 'EVM' }),
         });
@@ -167,7 +167,7 @@ To get started indexing EVM data on Moonbeam, you'll need to create a Subsquid p
         ```ts
         const processor = new EvmBatchProcessor();
         processor.setDataSource({
-          chain: {{ networks.moonbase.rpc_url }},
+          chain: '{{ networks.moonbase.rpc_url }}',
           // Resolves to 'https://moonbase-evm.archive.subsquid.io'
           archive: lookupArchive('moonbase', { type: 'EVM' }),
         });

--- a/builders/interoperability/xcm/xcm-transactor.md
+++ b/builders/interoperability/xcm/xcm-transactor.md
@@ -191,7 +191,7 @@ Now that you have the values for each of the parameters, you can write the scrip
 ```
 
 !!! note
-    You can view an example of the above script, which sends 1 xcUNIT to Alice's account on the relay chain, on [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/extrinsics/decode/0x210603010100e10d00017576e5e612ff054915d426c546b1b21a010000c52ebca2b10000000000000000007c030044236223ab4291b93eed10e4b511b37a398dee5513000064a7b3b6e00d02286bee02710200010300943577420d0300){target=_blank} using the following encoded calldata: `0x210603010100e10d00017576e5e612ff054915d426c546b1b21a010000c52ebca2b10000000000000000007c030044236223ab4291b93eed10e4b511b37a398dee5513000064a7b3b6e00d02286bee02710200010300943577420d0300`.
+    You can view an example of the above script, which sends 1 xcUNIT to Alice's account on the relay chain, on [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/extrinsics/decode/0x210603010100e10d00017576e5e612ff054915d426c546b1b21a010000c52ebca2b10000000000000000007c030044236223ab4291b93eed10e4b511b37a398dee5513000064a7b3b6e00d02286bee02710200010300943577420d030000){target=_blank} using the following encoded calldata: `0x210603010100e10d00017576e5e612ff054915d426c546b1b21a010000c52ebca2b10000000000000000007c030044236223ab4291b93eed10e4b511b37a398dee5513000064a7b3b6e00d02286bee02710200010300943577420d030000`.
 
 Once the transaction is processed, Alice should've received one token in her address on the destination chain.
 


### PR DESCRIPTION
### Description

- The encoded call format changed causing the original one to break for XCM transactor. 
- Chopsticks Command revisions
- Quick formatting change for Subsquid

Corresponding CN PR: https://github.com/moonbeam-foundation/moonbeam-docs-cn/pull/349

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
