### PR TITLE
remove onFinality Public endpoint

### DIFF
--- a/.snippets/code/tutorials/integrations/nft-subsquid/contract.ts
+++ b/.snippets/code/tutorials/integrations/nft-subsquid/contract.ts
@@ -4,7 +4,7 @@ import { BigNumber } from 'ethers';
 import { Context } from './processor';
 import { Contract } from './model';
 
-export const contractAddress = 'wss://moonbeam.api.onfinality.io/public-ws';
+export const contractAddress = 'wss://moonbeam.public.blastapi.io';
 
 export async function createContractEntity(ctx: Context): Promise<Contract> {
   const lastBlock = ctx.blocks[ctx.blocks.length - 1].header;

--- a/.snippets/text/builders/get-started/endpoints/moonbase.md
+++ b/.snippets/text/builders/get-started/endpoints/moonbase.md
@@ -1,18 +1,18 @@
 === "HTTPS"
-    |      Provider       |                             RPC URL                              |
-    |:-------------------:|:----------------------------------------------------------------:|
-    |        Blast        |    <pre>```https://moonbase-alpha.public.blastapi.io```</pre>    |
-    |       Dwellir       |        <pre>```https://moonbase-rpc.dwellir.com```</pre>         |
-    | Moonbeam Foundation |    <pre>```https://rpc.api.moonbase.moonbeam.network```</pre>    |
-    |     UnitedBloc      |         <pre>```https://moonbase.unitedbloc.com```</pre>         |
+    |      Provider       |                          RPC URL                           |
+    |:-------------------:|:----------------------------------------------------------:|
+    |        Blast        | <pre>```https://moonbase-alpha.public.blastapi.io```</pre> |
+    |       Dwellir       |     <pre>```https://moonbase-rpc.dwellir.com```</pre>      |
+    | Moonbeam Foundation | <pre>```https://rpc.api.moonbase.moonbeam.network```</pre> |
+    |     UnitedBloc      |      <pre>```https://moonbase.unitedbloc.com```</pre>      |
 
 === "WSS"
-    |      Provider       |                              RPC URL                              |
-    |:-------------------:|:-----------------------------------------------------------------:|
-    |        Blast        |     <pre>```wss://moonbase-alpha.public.blastapi.io```</pre>      |
-    |       Dwellir       |          <pre>```wss://moonbase-rpc.dwellir.com```</pre>          |
-    | Moonbeam Foundation |     <pre>```wss://wss.api.moonbase.moonbeam.network```</pre>      |
-    |     UnitedBloc      |          <pre>```wss://moonbase.unitedbloc.com```</pre>           |
+    |      Provider       |                         RPC URL                          |
+    |:-------------------:|:--------------------------------------------------------:|
+    |        Blast        | <pre>```wss://moonbase-alpha.public.blastapi.io```</pre> |
+    |       Dwellir       |     <pre>```wss://moonbase-rpc.dwellir.com```</pre>      |
+    | Moonbeam Foundation | <pre>```wss://wss.api.moonbase.moonbeam.network```</pre> |
+    |     UnitedBloc      |      <pre>```wss://moonbase.unitedbloc.com```</pre>      |
 
 #### Relay Chain {: #relay-chain }
 

--- a/.snippets/text/builders/get-started/endpoints/moonbase.md
+++ b/.snippets/text/builders/get-started/endpoints/moonbase.md
@@ -4,7 +4,6 @@
     |        Blast        |    <pre>```https://moonbase-alpha.public.blastapi.io```</pre>    |
     |       Dwellir       |        <pre>```https://moonbase-rpc.dwellir.com```</pre>         |
     | Moonbeam Foundation |    <pre>```https://rpc.api.moonbase.moonbeam.network```</pre>    |
-    |     OnFinality      | <pre>```https://moonbeam-alpha.api.onfinality.io/public```</pre> |
     |     UnitedBloc      |         <pre>```https://moonbase.unitedbloc.com```</pre>         |
 
 === "WSS"
@@ -13,7 +12,6 @@
     |        Blast        |     <pre>```wss://moonbase-alpha.public.blastapi.io```</pre>      |
     |       Dwellir       |          <pre>```wss://moonbase-rpc.dwellir.com```</pre>          |
     | Moonbeam Foundation |     <pre>```wss://wss.api.moonbase.moonbeam.network```</pre>      |
-    |     OnFinality      | <pre>```wss://moonbeam-alpha.api.onfinality.io/public-ws```</pre> |
     |     UnitedBloc      |          <pre>```wss://moonbase.unitedbloc.com```</pre>           |
 
 #### Relay Chain {: #relay-chain }

--- a/.snippets/text/builders/get-started/endpoints/moonbeam.md
+++ b/.snippets/text/builders/get-started/endpoints/moonbeam.md
@@ -8,8 +8,8 @@
     |  UnitedBloc  |                       <pre>```https://moonbeam.unitedbloc.com```</pre>                        |
 
 === "WSS"
-    |  Provider  |                           RPC URL                           |
-    |:----------:|:-----------------------------------------------------------:|
-    |   Blast    |     <pre>```wss://moonbeam.public.blastapi.io```</pre>      |
-    |  Dwellir   |       <pre>```wss://moonbeam-rpc.dwellir.com```</pre>       |
-    | UnitedBloc |       <pre>```wss://moonbeam.unitedbloc.com```</pre>        |
+    |  Provider  |                      RPC URL                       |
+    |:----------:|:--------------------------------------------------:|
+    |   Blast    | <pre>```wss://moonbeam.public.blastapi.io```</pre> |
+    |  Dwellir   |  <pre>```wss://moonbeam-rpc.dwellir.com```</pre>   |
+    | UnitedBloc |   <pre>```wss://moonbeam.unitedbloc.com```</pre>   |

--- a/.snippets/text/builders/get-started/endpoints/moonbeam.md
+++ b/.snippets/text/builders/get-started/endpoints/moonbeam.md
@@ -4,7 +4,6 @@
     |     1RPC     |                             <pre>```https://1rpc.io/glmr```</pre>                             |
     |    Blast     |                     <pre>```https://moonbeam.public.blastapi.io```</pre>                      |
     |   Dwellir    |                       <pre>```https://moonbeam-rpc.dwellir.com```</pre>                       |
-    |  OnFinality  |                  <pre>```https://moonbeam.api.onfinality.io/public```</pre>                   |
     | POKT Network | <pre>```https://moonbeam-mainnet.gateway.pokt.network/v1/lb/629a2b5650ec8c0039bb30f0```</pre> |
     |  UnitedBloc  |                       <pre>```https://moonbeam.unitedbloc.com```</pre>                        |
 
@@ -13,5 +12,4 @@
     |:----------:|:-----------------------------------------------------------:|
     |   Blast    |     <pre>```wss://moonbeam.public.blastapi.io```</pre>      |
     |  Dwellir   |       <pre>```wss://moonbeam-rpc.dwellir.com```</pre>       |
-    | OnFinality | <pre>```wss://moonbeam.api.onfinality.io/public-ws```</pre> |
     | UnitedBloc |       <pre>```wss://moonbeam.unitedbloc.com```</pre>        |

--- a/.snippets/text/builders/get-started/endpoints/moonriver.md
+++ b/.snippets/text/builders/get-started/endpoints/moonriver.md
@@ -3,7 +3,6 @@
     |:------------:|:----------------------------------------------------------------------------------------------:|
     |    Blast     |                     <pre>```https://moonriver.public.blastapi.io```</pre>                      |
     |   Dwellir    |                       <pre>```https://moonriver-rpc.dwellir.com```</pre>                       |
-    |  OnFinality  |                  <pre>```https://moonriver.api.onfinality.io/public```</pre>                   |
     | POKT Network | <pre>```https://moonriver-mainnet.gateway.pokt.network/v1/lb/62a74fdb123e6f003963642f```</pre> |
     |  UnitedBloc  |                       <pre>```https://moonriver.unitedbloc.com```</pre>                        |
 
@@ -12,5 +11,4 @@
     |:----------:|:------------------------------------------------------------:|
     |   Blast    |     <pre>```wss://moonriver.public.blastapi.io```</pre>      |
     |  Dwellir   |       <pre>```wss://moonriver-rpc.dwellir.com```</pre>       |
-    | OnFinality | <pre>```wss://moonriver.api.onfinality.io/public-ws```</pre> |
     | UnitedBloc |       <pre>```wss://moonriver.unitedbloc.com```</pre>        |

--- a/.snippets/text/builders/get-started/endpoints/moonriver.md
+++ b/.snippets/text/builders/get-started/endpoints/moonriver.md
@@ -7,8 +7,8 @@
     |  UnitedBloc  |                       <pre>```https://moonriver.unitedbloc.com```</pre>                        |
 
 === "WSS"
-    |  Provider  |                           RPC URL                            |
-    |:----------:|:------------------------------------------------------------:|
-    |   Blast    |     <pre>```wss://moonriver.public.blastapi.io```</pre>      |
-    |  Dwellir   |       <pre>```wss://moonriver-rpc.dwellir.com```</pre>       |
-    | UnitedBloc |       <pre>```wss://moonriver.unitedbloc.com```</pre>        |
+    |  Provider  |                       RPC URL                       |
+    |:----------:|:---------------------------------------------------:|
+    |   Blast    | <pre>```wss://moonriver.public.blastapi.io```</pre> |
+    |  Dwellir   |  <pre>```wss://moonriver-rpc.dwellir.com```</pre>   |
+    | UnitedBloc |   <pre>```wss://moonriver.unitedbloc.com```</pre>   |

--- a/builders/get-started/endpoints.md
+++ b/builders/get-started/endpoints.md
@@ -89,7 +89,7 @@ Creating a new API key is simple, all you have to do is:
 
 ### OnFinality {: #onfinality }
 
-[OnFinality](https://onfinality.io/){target=_blank} provides a free API key based endpoint for customers that provide higher rate limits and performance than the free public endpoint. You also receive more in depth analytics of the usage of your application.
+[OnFinality](https://onfinality.io/){target=_blank} provides a free API key based endpoint for customers in place of a public endpoint. Additionally, OnFinality offers paid tiers of service that offer increased rate limits and higher performance than those offered by the free tier. You also receive more in depth analytics of the usage of your application.
 
 To create a custom OnFinality endpoint, go to [OnFinality](https://onfinality.io/){target=_blank} and sign up, or if you already have signed up you can go ahead and log in. From the OnFinality **Dashboard**, you can:
 

--- a/builders/get-started/quick-start.md
+++ b/builders/get-started/quick-start.md
@@ -35,23 +35,22 @@ When working with developer tools, depending on the tool, you might need to conf
     |:---------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
     |    Chain ID     |                                                                               <pre>```{{ networks.moonbeam.chain_id }}```</pre>                                                                                |
     | Public RPC URLs | <pre>```https://moonbeam.public.blastapi.io```</pre> <pre>```https://moonbeam.api.onfinality.io/public```</pre>  <pre>```https://moonbeam-mainnet.gateway.pokt.network/v1/lb/629a2b5650ec8c0039bb30f0```</pre> |
-    | Public WSS URLs |                                                 <pre>```wss://moonbeam.public.blastapi.io```</pre> <pre>```wss://moonbeam.api.onfinality.io/public-ws```</pre>                                                 |
-
+    | Public WSS URLs |                                                 <pre>```wss://moonbeam.public.blastapi.io```</pre>
 === "Moonriver"
 
     |    Variable     |                                                                                                       Value                                                                                                       |
     |:---------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
     |    Chain ID     |                                                                                <pre>```{{ networks.moonriver.chain_id }}```</pre>                                                                                 |
     | Public RPC URLs | <pre>```https://moonriver.public.blastapi.io```</pre> <pre>```https://moonriver.api.onfinality.io/public```</pre>  <pre>```https://moonriver-mainnet.gateway.pokt.network/v1/lb/62a74fdb123e6f003963642f```</pre> |
-    | Public WSS URLs |                                                 <pre>```wss://moonriver.public.blastapi.io```</pre> <pre>```wss://moonriver.api.onfinality.io/public-ws```</pre>                                                  |
+    | Public WSS URLs |                                                 <pre>```wss://moonriver.public.blastapi.io```</pre>
 
 === "Moonbase Alpha"
 
     |    Variable     |                                                                                    Value                                                                                     |
     |:---------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
     |    Chain ID     |                                                              <pre>```{{ networks.moonbase.chain_id }}```</pre>                                                               |
-    | Public RPC URLs | <pre>```https://moonbase-alpha.public.blastapi.io```</pre> <pre>```https://moonbeam-alpha.api.onfinality.io/public```</pre> <pre>```{{ networks.moonbase.rpc_url }}```</pre> |
-    | Public WSS URLs | <pre>```wss://moonbase-alpha.public.blastapi.io```</pre> <pre>```wss://moonbeam-alpha.api.onfinality.io/public-ws```</pre> <pre>```{{ networks.moonbase.wss_url }}```</pre>  |
+    | Public RPC URLs | <pre>```https://moonbase-alpha.public.blastapi.io```</pre> <pre>```{{ networks.moonbase.rpc_url }}```</pre> |
+    | Public WSS URLs | <pre>```wss://moonbase-alpha.public.blastapi.io```</pre> <pre>```{{ networks.moonbase.wss_url }}```</pre>  |
 
 === "Moonbeam Dev Node"
 

--- a/builders/get-started/quick-start.md
+++ b/builders/get-started/quick-start.md
@@ -34,14 +34,14 @@ When working with developer tools, depending on the tool, you might need to conf
     |    Variable     |                                                                                                     Value                                                                                                      |
     |:---------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
     |    Chain ID     |                                                                               <pre>```{{ networks.moonbeam.chain_id }}```</pre>                                                                                |
-    | Public RPC URLs | <pre>```https://moonbeam.public.blastapi.io```</pre> <pre>```https://moonbeam.api.onfinality.io/public```</pre>  <pre>```https://moonbeam-mainnet.gateway.pokt.network/v1/lb/629a2b5650ec8c0039bb30f0```</pre> |
+    | Public RPC URLs | <pre>```https://moonbeam.public.blastapi.io```</pre>  <pre>```https://moonbeam-mainnet.gateway.pokt.network/v1/lb/629a2b5650ec8c0039bb30f0```</pre> |
     | Public WSS URLs |                                                 <pre>```wss://moonbeam.public.blastapi.io```</pre>
 === "Moonriver"
 
     |    Variable     |                                                                                                       Value                                                                                                       |
     |:---------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
     |    Chain ID     |                                                                                <pre>```{{ networks.moonriver.chain_id }}```</pre>                                                                                 |
-    | Public RPC URLs | <pre>```https://moonriver.public.blastapi.io```</pre> <pre>```https://moonriver.api.onfinality.io/public```</pre>  <pre>```https://moonriver-mainnet.gateway.pokt.network/v1/lb/62a74fdb123e6f003963642f```</pre> |
+    | Public RPC URLs | <pre>```https://moonriver.public.blastapi.io```</pre>  <pre>```https://moonriver-mainnet.gateway.pokt.network/v1/lb/62a74fdb123e6f003963642f```</pre> |
     | Public WSS URLs |                                                 <pre>```wss://moonriver.public.blastapi.io```</pre>
 
 === "Moonbase Alpha"

--- a/builders/get-started/quick-start.md
+++ b/builders/get-started/quick-start.md
@@ -7,9 +7,9 @@ description: Everything you need to know to get started developing, deploying, a
 
 ## Quick Overview {: #overview }
 
-Moonbeam is a fully Ethereum-compatible smart contract platform on Polkadot. As such, you can interact with Moonbeam via the [Ethereum API](/builders/build/eth-api/){target=\_blank} and [Substrate API](/builders/build/substrate-api/){target=\_blank}.
+Moonbeam is a fully Ethereum-compatible smart contract platform on Polkadot. As such, you can interact with Moonbeam via the [Ethereum API](/builders/build/eth-api/){target=_blank} and [Substrate API](/builders/build/substrate-api/){target=_blank}.
 
-Although Moonbeam is a Substrate-based platform, Moonbeam uses a [unified accounts](/learn/features/unified-accounts){target=\_blank} system, which replaces Substrate-style accounts and keys with Ethereum-style accounts and keys. As a result, you can interact with your Moonbeam account with [MetaMask](/tokens/connect/metamask){target=\_blank}, [Ledger](/tokens/connect/ledger/){target=\_blank}, and other Ethereum-compatible wallets by simply adding Moonbeam's network configurations. Similarly, you can develop on Moonbeam using Ethereum [libraries](/builders/build/eth-api/libraries/){target=\_blank} and [development environments](/builders/build/eth-api/dev-env/){target=\_blank}.
+Although Moonbeam is a Substrate-based platform, Moonbeam uses a [unified accounts](/learn/features/unified-accounts){target=_blank} system, which replaces Substrate-style accounts and keys with Ethereum-style accounts and keys. As a result, you can interact with your Moonbeam account with [MetaMask](/tokens/connect/metamask){target=_blank}, [Ledger](/tokens/connect/ledger/){target=_blank}, and other Ethereum-compatible wallets by simply adding Moonbeam's network configurations. Similarly, you can develop on Moonbeam using Ethereum [libraries](/builders/build/eth-api/libraries/){target=_blank} and [development environments](/builders/build/eth-api/dev-env/){target=_blank}.
 
 ## Moonbeam Networks {: #moonbeam-networks }
 
@@ -17,13 +17,13 @@ To get started developing on Moonbeam, it's important to be aware of the various
 
 |                                         Network                                          | Network Type  |                                   Relay Chain                                   | Native Asset Symbol | Native Asset Decimals |
 |:----------------------------------------------------------------------------------------:|:-------------:|:-------------------------------------------------------------------------------:|:-------------------:|:---------------------:|
-|           [Moonbeam](/builders/get-started/networks/moonbeam){target=\_blank}            |    MainNet    |              [Polkadot](https://polkadot.network/){target=\_blank}              |        GLMR         |          18           |
-|          [Moonriver](/builders/get-started/networks/moonriver){target=\_blank}           |    MainNet    |                [Kusama](https://kusama.network/){target=\_blank}                |        MOVR         |          18           |
-|        [Moonbase Alpha](/builders/get-started/networks/moonbase){target=\_blank}         |    TestNet    | [Alphanet relay](/learn/platform/networks/moonbase#relay-chain){target=\_blank} |         DEV         |          18           |
-| [Moonbeam Development Node](/builders/get-started/networks/moonbeam-dev){target=\_blank} | Local TestNet |                                      None                                       |         DEV         |          18           |
+|           [Moonbeam](/builders/get-started/networks/moonbeam){target=_blank}            |    MainNet    |              [Polkadot](https://polkadot.network/){target=_blank}              |        GLMR         |          18           |
+|          [Moonriver](/builders/get-started/networks/moonriver){target=_blank}           |    MainNet    |                [Kusama](https://kusama.network/){target=_blank}                |        MOVR         |          18           |
+|        [Moonbase Alpha](/builders/get-started/networks/moonbase){target=_blank}         |    TestNet    | [Alphanet relay](/learn/platform/networks/moonbase#relay-chain){target=_blank} |         DEV         |          18           |
+| [Moonbeam Development Node](/builders/get-started/networks/moonbeam-dev){target=_blank} | Local TestNet |                                      None                                       |         DEV         |          18           |
 
 !!! note
-A Moonbeam development node doesn't have a relay chain as its purpose is to be your own personal development environment where you can get started developing quickly without the overhead of a relay chain.
+    A Moonbeam development node doesn't have a relay chain as its purpose is to be your own personal development environment where you can get started developing quickly without the overhead of a relay chain.
 
 ### Network Configurations {: #network-configurations }
 
@@ -62,11 +62,11 @@ When working with developer tools, depending on the tool, you might need to conf
     | Local WSS URL | <pre>```{{ networks.development.wss_url }}```</pre>  |
 
 !!! note
-You can create your own endpoint suitable for development or production from one of the [supported RPC providers](/builders/get-started/endpoints/#endpoint-providers){target=\_blank}.
+    You can create your own endpoint suitable for development or production from one of the [supported RPC providers](/builders/get-started/endpoints/#endpoint-providers){target=_blank}.
 
 ### Block Explorers {: #explorers }
 
-Moonbeam provides two different kind of explorers: ones to query the Ethereum API, and others dedicated to the Substrate API. All EVM-based transactions are accessible via the Ethereum API wheras the Substrate API can be relied upon for Substrate-native functions such as governance, staking, and some information about EVM-based transactions. For more information on each explorer, please check out the [Block Explorers](/builders/get-started/explorers){target=\_blank} page.
+Moonbeam provides two different kind of explorers: ones to query the Ethereum API, and others dedicated to the Substrate API. All EVM-based transactions are accessible via the Ethereum API wheras the Substrate API can be relied upon for Substrate-native functions such as governance, staking, and some information about EVM-based transactions. For more information on each explorer, please check out the [Block Explorers](/builders/get-started/explorers){target=_blank} page.
 
 --8<-- 'text/builders/get-started/explorers/explorers.md'
 
@@ -76,8 +76,8 @@ To get started developing on one of the TestNets, you'll need to fund your accou
 
 |                                         TestNet                                          |                                                                           Where To Get Tokens From                                                                            |
 |:----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-|        [Moonbase Alpha](/builders/get-started/networks/moonbase){target=\_blank}         | The [Moonbase Alpha Faucet](https://faucet.moonbeam.network/){target=\_blank} website. <br> The faucet dispenses {{ networks.moonbase.website_faucet_amount }} every 24 hours |
-| [Moonbeam Development Node](/builders/get-started/networks/moonbeam-dev){target=\_blank} | Any of the [ten pre-funded accounts](/builders/get-started/networks/moonbeam-dev/#pre-funded-development-accounts){target=\_blank} that come with your <br> development node  |
+|        [Moonbase Alpha](/builders/get-started/networks/moonbase){target=_blank}         | The [Moonbase Alpha Faucet](https://faucet.moonbeam.network/){target=_blank} website. <br> The faucet dispenses {{ networks.moonbase.website_faucet_amount }} every 24 hours |
+| [Moonbeam Development Node](/builders/get-started/networks/moonbeam-dev){target=_blank} | Any of the [ten pre-funded accounts](/builders/get-started/networks/moonbeam-dev/#pre-funded-development-accounts){target=_blank} that come with your <br> development node  |
 
 ## Development Tools {: #development-tools }
 
@@ -86,32 +86,36 @@ As Moonbeam is a Substrate-based chain that is fully Ethereum-compatible, you ca
 ### JavaScript Tools {: #javascript }
 
 === "Ethereum"
-|                                     Tool                                      |      Type       |
-|:-----------------------------------------------------------------------------:|:---------------:|
-|    [Ethers.js](/builders/build/eth-api/libraries/ethersjs){target=\_blank}    |     Library     |
-|      [Web3.js](/builders/build/eth-api/libraries/web3js){target=\_blank}      |     Library     |
-|      [Hardhat](/builders/build/eth-api/dev-env/hardhat){target=\_blank}       | Dev Environment |
-| [OpenZeppelin](/builders/build/eth-api/dev-env/openzeppelin/){target=\_blank} | Dev Environment |
-|        [Remix](/builders/build/eth-api/dev-env/remix){target=\_blank}         | Dev Environment |
-| [Scaffold-Eth](/builders/build/eth-api/dev-env/scaffold-eth){target=\_blank}  | Dev Environment |
-|     [thirdweb](/builders/build/eth-api/dev-env/thirdweb){target=\_blank}      | Dev Environment |
-| [Waffle & Mars](/builders/build/eth-api/dev-env/waffle-mars){target=\_blank}  | Dev Environment |
+
+    |                                     Tool                                      |      Type       |
+    |:-----------------------------------------------------------------------------:|:---------------:|
+    |    [Ethers.js](/builders/build/eth-api/libraries/ethersjs){target=_blank}    |     Library     |
+    |      [Web3.js](/builders/build/eth-api/libraries/web3js){target=_blank}      |     Library     |
+    |      [Hardhat](/builders/build/eth-api/dev-env/hardhat){target=_blank}       | Dev Environment |
+    | [OpenZeppelin](/builders/build/eth-api/dev-env/openzeppelin/){target=_blank} | Dev Environment |
+    |        [Remix](/builders/build/eth-api/dev-env/remix){target=_blank}         | Dev Environment |
+    | [Scaffold-Eth](/builders/build/eth-api/dev-env/scaffold-eth){target=_blank}  | Dev Environment |
+    |     [thirdweb](/builders/build/eth-api/dev-env/thirdweb){target=_blank}      | Dev Environment |
+    | [Waffle & Mars](/builders/build/eth-api/dev-env/waffle-mars){target=_blank}  | Dev Environment |
 
 === "Substrate"
-|                                       Tool                                       |  Type   |
-|:--------------------------------------------------------------------------------:|:-------:|
-| [Polkadot.js API](/builders/build/substrate-api/polkadot-js-api){target=\_blank} | Library |
+
+    |                                       Tool                                       |  Type   |
+    |:--------------------------------------------------------------------------------:|:-------:|
+    | [Polkadot.js API](/builders/build/substrate-api/polkadot-js-api){target=_blank} | Library |
 
 ### Python Tools {: #python }
 
 === "Ethereum"
-|                                Tool                                 |      Type       |
-|:-------------------------------------------------------------------:|:---------------:|
-| [Web3.py](/builders/build/eth-api/libraries/web3py){target=\_blank} |     Library     |
-| [Brownie](/builders/build/eth-api/dev-env/brownie){target=\_blank}  | Dev Environment |
-|   [thirdweb](https://portal.thirdweb.com/python){target=\_blank}    | Dev Environment |
+
+    |                                Tool                                 |      Type       |
+    |:-------------------------------------------------------------------:|:---------------:|
+    | [Web3.py](/builders/build/eth-api/libraries/web3py){target=_blank} |     Library     |
+    | [Brownie](/builders/build/eth-api/dev-env/brownie){target=_blank}  | Dev Environment |
+    |   [thirdweb](https://portal.thirdweb.com/python){target=_blank}    | Dev Environment |
 
 === "Substrate"
-|                                              Tool                                              |  Type   |
-|:----------------------------------------------------------------------------------------------:|:-------:|
-| [Py Substrate Interface](/builders/build/substrate-api/py-substrate-interface){target=\_blank} | Library |
+
+    |                                              Tool                                              |  Type   |
+    |:----------------------------------------------------------------------------------------------:|:-------:|
+    | [Py Substrate Interface](/builders/build/substrate-api/py-substrate-interface){target=_blank} | Library |

--- a/builders/get-started/quick-start.md
+++ b/builders/get-started/quick-start.md
@@ -7,23 +7,23 @@ description: Everything you need to know to get started developing, deploying, a
 
 ## Quick Overview {: #overview }
 
-Moonbeam is a fully Ethereum-compatible smart contract platform on Polkadot. As such, you can interact with Moonbeam via the [Ethereum API](/builders/build/eth-api/){target=_blank} and [Substrate API](/builders/build/substrate-api/){target=_blank}.
+Moonbeam is a fully Ethereum-compatible smart contract platform on Polkadot. As such, you can interact with Moonbeam via the [Ethereum API](/builders/build/eth-api/){target=\_blank} and [Substrate API](/builders/build/substrate-api/){target=\_blank}.
 
-Although Moonbeam is a Substrate-based platform, Moonbeam uses a [unified accounts](/learn/features/unified-accounts){target=_blank} system, which replaces Substrate-style accounts and keys with Ethereum-style accounts and keys. As a result, you can interact with your Moonbeam account with [MetaMask](/tokens/connect/metamask){target=_blank}, [Ledger](/tokens/connect/ledger/){target=_blank}, and other Ethereum-compatible wallets by simply adding Moonbeam's network configurations. Similarly, you can develop on Moonbeam using Ethereum [libraries](/builders/build/eth-api/libraries/){target=_blank} and [development environments](/builders/build/eth-api/dev-env/){target=_blank}.
+Although Moonbeam is a Substrate-based platform, Moonbeam uses a [unified accounts](/learn/features/unified-accounts){target=\_blank} system, which replaces Substrate-style accounts and keys with Ethereum-style accounts and keys. As a result, you can interact with your Moonbeam account with [MetaMask](/tokens/connect/metamask){target=\_blank}, [Ledger](/tokens/connect/ledger/){target=\_blank}, and other Ethereum-compatible wallets by simply adding Moonbeam's network configurations. Similarly, you can develop on Moonbeam using Ethereum [libraries](/builders/build/eth-api/libraries/){target=\_blank} and [development environments](/builders/build/eth-api/dev-env/){target=\_blank}.
 
 ## Moonbeam Networks {: #moonbeam-networks }
 
 To get started developing on Moonbeam, it's important to be aware of the various networks within the Moonbeam ecosystem.
 
-|                                         Network                                         | Network Type  |                                  Relay Chain                                   | Native Asset Symbol | Native Asset Decimals |
-|:---------------------------------------------------------------------------------------:|:-------------:|:------------------------------------------------------------------------------:|:-------------------:|:---------------------:|
-|           [Moonbeam](/builders/get-started/networks/moonbeam){target=_blank}            |    MainNet    |              [Polkadot](https://polkadot.network/){target=_blank}              |        GLMR         |          18           |
-|          [Moonriver](/builders/get-started/networks/moonriver){target=_blank}           |    MainNet    |                [Kusama](https://kusama.network/){target=_blank}                |        MOVR         |          18           |
-|        [Moonbase Alpha](/builders/get-started/networks/moonbase){target=_blank}         |    TestNet    | [Alphanet relay](/learn/platform/networks/moonbase#relay-chain){target=_blank} |         DEV         |          18           |
-| [Moonbeam Development Node](/builders/get-started/networks/moonbeam-dev){target=_blank} | Local TestNet |                                      None                                      |         DEV         |          18           |
+|                                         Network                                          | Network Type  |                                   Relay Chain                                   | Native Asset Symbol | Native Asset Decimals |
+|:----------------------------------------------------------------------------------------:|:-------------:|:-------------------------------------------------------------------------------:|:-------------------:|:---------------------:|
+|           [Moonbeam](/builders/get-started/networks/moonbeam){target=\_blank}            |    MainNet    |              [Polkadot](https://polkadot.network/){target=\_blank}              |        GLMR         |          18           |
+|          [Moonriver](/builders/get-started/networks/moonriver){target=\_blank}           |    MainNet    |                [Kusama](https://kusama.network/){target=\_blank}                |        MOVR         |          18           |
+|        [Moonbase Alpha](/builders/get-started/networks/moonbase){target=\_blank}         |    TestNet    | [Alphanet relay](/learn/platform/networks/moonbase#relay-chain){target=\_blank} |         DEV         |          18           |
+| [Moonbeam Development Node](/builders/get-started/networks/moonbeam-dev){target=\_blank} | Local TestNet |                                      None                                       |         DEV         |          18           |
 
 !!! note
-    A Moonbeam development node doesn't have a relay chain as its purpose is to be your own personal development environment where you can get started developing quickly without the overhead of a relay chain.
+A Moonbeam development node doesn't have a relay chain as its purpose is to be your own personal development environment where you can get started developing quickly without the overhead of a relay chain.
 
 ### Network Configurations {: #network-configurations }
 
@@ -31,26 +31,27 @@ When working with developer tools, depending on the tool, you might need to conf
 
 === "Moonbeam"
 
-    |    Variable     |                                                                                                     Value                                                                                                      |
-    |:---------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-    |    Chain ID     |                                                                               <pre>```{{ networks.moonbeam.chain_id }}```</pre>                                                                                |
+    |    Variable     |                                                                        Value                                                                        |
+    |:---------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------:|
+    |    Chain ID     |                                                  <pre>```{{ networks.moonbeam.chain_id }}```</pre>                                                  |
     | Public RPC URLs | <pre>```https://moonbeam.public.blastapi.io```</pre>  <pre>```https://moonbeam-mainnet.gateway.pokt.network/v1/lb/629a2b5650ec8c0039bb30f0```</pre> |
-    | Public WSS URLs |                                                 <pre>```wss://moonbeam.public.blastapi.io```</pre>
+    | Public WSS URLs |                                                 <pre>```wss://moonbeam.public.blastapi.io```</pre>                                                  |
+
 === "Moonriver"
 
-    |    Variable     |                                                                                                       Value                                                                                                       |
-    |:---------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-    |    Chain ID     |                                                                                <pre>```{{ networks.moonriver.chain_id }}```</pre>                                                                                 |
+    |    Variable     |                                                                         Value                                                                         |
+    |:---------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------:|
+    |    Chain ID     |                                                  <pre>```{{ networks.moonriver.chain_id }}```</pre>                                                   |
     | Public RPC URLs | <pre>```https://moonriver.public.blastapi.io```</pre>  <pre>```https://moonriver-mainnet.gateway.pokt.network/v1/lb/62a74fdb123e6f003963642f```</pre> |
-    | Public WSS URLs |                                                 <pre>```wss://moonriver.public.blastapi.io```</pre>
+    | Public WSS URLs |                                                  <pre>```wss://moonriver.public.blastapi.io```</pre>                                                  |
 
 === "Moonbase Alpha"
 
-    |    Variable     |                                                                                    Value                                                                                     |
-    |:---------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-    |    Chain ID     |                                                              <pre>```{{ networks.moonbase.chain_id }}```</pre>                                                               |
+    |    Variable     |                                                    Value                                                    |
+    |:---------------:|:-----------------------------------------------------------------------------------------------------------:|
+    |    Chain ID     |                              <pre>```{{ networks.moonbase.chain_id }}```</pre>                              |
     | Public RPC URLs | <pre>```https://moonbase-alpha.public.blastapi.io```</pre> <pre>```{{ networks.moonbase.rpc_url }}```</pre> |
-    | Public WSS URLs | <pre>```wss://moonbase-alpha.public.blastapi.io```</pre> <pre>```{{ networks.moonbase.wss_url }}```</pre>  |
+    | Public WSS URLs |  <pre>```wss://moonbase-alpha.public.blastapi.io```</pre> <pre>```{{ networks.moonbase.wss_url }}```</pre>  |
 
 === "Moonbeam Dev Node"
 
@@ -61,11 +62,11 @@ When working with developer tools, depending on the tool, you might need to conf
     | Local WSS URL | <pre>```{{ networks.development.wss_url }}```</pre>  |
 
 !!! note
-    You can create your own endpoint suitable for development or production from one of the [supported RPC providers](/builders/get-started/endpoints/#endpoint-providers){target=_blank}.
+You can create your own endpoint suitable for development or production from one of the [supported RPC providers](/builders/get-started/endpoints/#endpoint-providers){target=\_blank}.
 
 ### Block Explorers {: #explorers }
 
-Moonbeam provides two different kind of explorers: ones to query the Ethereum API, and others dedicated to the Substrate API. All EVM-based transactions are accessible via the Ethereum API wheras the Substrate API can be relied upon for Substrate-native functions such as governance, staking, and some information about EVM-based transactions. For more information on each explorer, please check out the [Block Explorers](/builders/get-started/explorers){target=_blank} page.
+Moonbeam provides two different kind of explorers: ones to query the Ethereum API, and others dedicated to the Substrate API. All EVM-based transactions are accessible via the Ethereum API wheras the Substrate API can be relied upon for Substrate-native functions such as governance, staking, and some information about EVM-based transactions. For more information on each explorer, please check out the [Block Explorers](/builders/get-started/explorers){target=\_blank} page.
 
 --8<-- 'text/builders/get-started/explorers/explorers.md'
 
@@ -73,10 +74,10 @@ Moonbeam provides two different kind of explorers: ones to query the Ethereum AP
 
 To get started developing on one of the TestNets, you'll need to fund your account with DEV tokens to send transactions. Please note that DEV tokens have no real value and are for testing purposes only.
 
-|                                         TestNet                                         |                                                                           Where To Get Tokens From                                                                           |
-|:---------------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-|        [Moonbase Alpha](/builders/get-started/networks/moonbase){target=_blank}         | The [Moonbase Alpha Faucet](https://faucet.moonbeam.network/){target=_blank} website. <br> The faucet dispenses {{ networks.moonbase.website_faucet_amount }} every 24 hours |
-| [Moonbeam Development Node](/builders/get-started/networks/moonbeam-dev){target=_blank} | Any of the [ten pre-funded accounts](/builders/get-started/networks/moonbeam-dev/#pre-funded-development-accounts){target=_blank} that come with your <br> development node  |
+|                                         TestNet                                          |                                                                           Where To Get Tokens From                                                                            |
+|:----------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+|        [Moonbase Alpha](/builders/get-started/networks/moonbase){target=\_blank}         | The [Moonbase Alpha Faucet](https://faucet.moonbeam.network/){target=\_blank} website. <br> The faucet dispenses {{ networks.moonbase.website_faucet_amount }} every 24 hours |
+| [Moonbeam Development Node](/builders/get-started/networks/moonbeam-dev){target=\_blank} | Any of the [ten pre-funded accounts](/builders/get-started/networks/moonbeam-dev/#pre-funded-development-accounts){target=\_blank} that come with your <br> development node  |
 
 ## Development Tools {: #development-tools }
 
@@ -85,32 +86,32 @@ As Moonbeam is a Substrate-based chain that is fully Ethereum-compatible, you ca
 ### JavaScript Tools {: #javascript }
 
 === "Ethereum"
-    |                                     Tool                                     |      Type       |
-    |:----------------------------------------------------------------------------:|:---------------:|
-    |    [Ethers.js](/builders/build/eth-api/libraries/ethersjs){target=_blank}    |     Library     |
-    |      [Web3.js](/builders/build/eth-api/libraries/web3js){target=_blank}      |     Library     |
-    |      [Hardhat](/builders/build/eth-api/dev-env/hardhat){target=_blank}       | Dev Environment |
-    | [OpenZeppelin](/builders/build/eth-api/dev-env/openzeppelin/){target=_blank} | Dev Environment |
-    |        [Remix](/builders/build/eth-api/dev-env/remix){target=_blank}         | Dev Environment |
-    | [Scaffold-Eth](/builders/build/eth-api/dev-env/scaffold-eth){target=_blank}  | Dev Environment |
-    |     [thirdweb](/builders/build/eth-api/dev-env/thirdweb){target=_blank}      | Dev Environment |
-    | [Waffle & Mars](/builders/build/eth-api/dev-env/waffle-mars){target=_blank}  | Dev Environment |
+|                                     Tool                                      |      Type       |
+|:-----------------------------------------------------------------------------:|:---------------:|
+|    [Ethers.js](/builders/build/eth-api/libraries/ethersjs){target=\_blank}    |     Library     |
+|      [Web3.js](/builders/build/eth-api/libraries/web3js){target=\_blank}      |     Library     |
+|      [Hardhat](/builders/build/eth-api/dev-env/hardhat){target=\_blank}       | Dev Environment |
+| [OpenZeppelin](/builders/build/eth-api/dev-env/openzeppelin/){target=\_blank} | Dev Environment |
+|        [Remix](/builders/build/eth-api/dev-env/remix){target=\_blank}         | Dev Environment |
+| [Scaffold-Eth](/builders/build/eth-api/dev-env/scaffold-eth){target=\_blank}  | Dev Environment |
+|     [thirdweb](/builders/build/eth-api/dev-env/thirdweb){target=\_blank}      | Dev Environment |
+| [Waffle & Mars](/builders/build/eth-api/dev-env/waffle-mars){target=\_blank}  | Dev Environment |
 
 === "Substrate"
-    |                                      Tool                                       |  Type   |
-    |:-------------------------------------------------------------------------------:|:-------:|
-    | [Polkadot.js API](/builders/build/substrate-api/polkadot-js-api){target=_blank} | Library |
+|                                       Tool                                       |  Type   |
+|:--------------------------------------------------------------------------------:|:-------:|
+| [Polkadot.js API](/builders/build/substrate-api/polkadot-js-api){target=\_blank} | Library |
 
 ### Python Tools {: #python }
 
 === "Ethereum"
-    |                                Tool                                |      Type       |
-    |:------------------------------------------------------------------:|:---------------:|
-    | [Web3.py](/builders/build/eth-api/libraries/web3py){target=_blank} |     Library     |
-    | [Brownie](/builders/build/eth-api/dev-env/brownie){target=_blank}  | Dev Environment |
-    |   [thirdweb](https://portal.thirdweb.com/python){target=_blank}    | Dev Environment |
+|                                Tool                                 |      Type       |
+|:-------------------------------------------------------------------:|:---------------:|
+| [Web3.py](/builders/build/eth-api/libraries/web3py){target=\_blank} |     Library     |
+| [Brownie](/builders/build/eth-api/dev-env/brownie){target=\_blank}  | Dev Environment |
+|   [thirdweb](https://portal.thirdweb.com/python){target=\_blank}    | Dev Environment |
 
 === "Substrate"
-    |                                             Tool                                              |  Type   |
-    |:---------------------------------------------------------------------------------------------:|:-------:|
-    | [Py Substrate Interface](/builders/build/substrate-api/py-substrate-interface){target=_blank} | Library |
+|                                              Tool                                              |  Type   |
+|:----------------------------------------------------------------------------------------------:|:-------:|
+| [Py Substrate Interface](/builders/build/substrate-api/py-substrate-interface){target=\_blank} | Library |


### PR DESCRIPTION
### Description

Removes OnFinality public endpoints from the endpoints page. OnFinality private endpoints and paid endpoints are not impacted and remain unchanged. For more information, please see: https://forum.moonbeam.network/t/proposal-mb19-mr14-onfinality-high-performance-public-infrastructure-transition-project/1303

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### Corresponding PRs

https://github.com/moonbeam-foundation/moonbeam-docs-cn/pull/350.

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
