### PR TITLE
add support for MBIP-5 on moonriver

### DIFF
--- a/builders/get-started/eth-compare/tx-fees.md
+++ b/builders/get-started/eth-compare/tx-fees.md
@@ -21,7 +21,7 @@ There are some key differences between the transaction fee model on Moonbeam and
 
   - The EVM is designed to solely have capacity for gas and Moonbeam requires additional metrics outside of gas. In particular, Moonbeam needs the ability to record proof size, which is the amount of storage required on Moonbeam for a relay chain validator to verify a state transition. When the capacity limit for proof size has been reached for the current block, which is 25% of the block limit, an "Out of Gas" error will be thrown. This can happen even if there is remaining *legacy* gas in the gasometer. This additional metric also impacts refunds. Refunds are based on the more consumed resource after the execution. In other words, if more proof size has been consumed proportionally than legacy gas, the refund will be calculated using proof size
 
-  - Moonbeam has implemented a new mechanism defined in [MBIP-5](https://github.com/moonbeam-foundation/moonbeam/blob/master/MBIPS/MBIP-5.md){target=_blank} that limits block storage and increases gas usage for transactions that result in an increase in storage. Please note that this feature is only enabled on Moonbase Alpha at this time
+  - Moonbeam has implemented a new mechanism defined in [MBIP-5](https://github.com/moonbeam-foundation/moonbeam/blob/master/MBIPS/MBIP-5.md){target=_blank} that limits block storage and increases gas usage for transactions that result in an increase in storage. Please note that this feature is only enabled on Moonriver and Moonbase Alpha at this time
 
 ## Overview of MBIP-5 {: #overview-of-mbip-5 }
 
@@ -29,7 +29,19 @@ MBIP-5 introduced changes to Moonbeam's fee mechanism that account for storage g
 
 This impacts contract deployments that add to the chain state, transactions that create new storage entries, and precompiled contract calls that result in the creation of new accounts.
 
-The block storage limit prevents transactions in a single block from collectively increasing the storage state by more than {{ networks.moonbase.mbip_5.block_storage_limit }}KB.
+The block storage limit prevents transactions in a single block from collectively increasing the storage state by more than the limit. The limit for each network is as follows:
+
+=== "Moonriver"
+
+    ```text
+    {{ networks.moonriver.mbip_5.block_storage_limit }}KB
+    ```
+
+=== "Moonbase Alpha"
+
+    ```text
+    {{ networks.moonbase.mbip_5.block_storage_limit }}KB
+    ```
 
 To determine the amount of gas for storage in bytes, there is a ratio that is defined as:
 
@@ -37,19 +49,51 @@ To determine the amount of gas for storage in bytes, there is a ratio that is de
 Ratio = Block Gas Limit / (Block Storage Limit * 1024 Bytes)
 ```
 
-Given the block gas limit of {{ networks.moonbase.gas_block }} and the block storage limit of {{ networks.moonbase.mbip_5.block_storage_limit }}KB per block, the ratio between gas and storage is {{ networks.moonbase.mbip_5.gas_storage_ratio }}, which is calculated like this:
+The block gas limit for each network is as follows:
 
-```text
-Ratio = {{ networks.moonbase.gas_block_numbers_only }} / ({{ networks.moonbase.mbip_5.block_storage_limit }} * 1024)
-Ratio = {{ networks.moonbase.mbip_5.gas_storage_ratio }} 
-```
+=== "Moonriver"
+
+    ```text
+    {{ networks.moonriver.gas_block }}
+    ```
+
+=== "Moonbase Alpha"
+
+    ```text
+    {{ networks.moonbase.gas_block }}
+    ```
+
+Knowing the block gas and storage limits, the ratio of gas to storage is computed as follows:
+
+=== "Moonriver"
+
+    ```text
+    Ratio = {{ networks.moonriver.gas_block_numbers_only }} / ({{ networks.moonriver.mbip_5.block_storage_limit }} * 1024)
+    Ratio = {{ networks.moonriver.mbip_5.gas_storage_ratio }} 
+    ```
+
+=== "Moonbase Alpha"
+
+    ```text
+    Ratio = {{ networks.moonbase.gas_block_numbers_only }} / ({{ networks.moonbase.mbip_5.block_storage_limit }} * 1024)
+    Ratio = {{ networks.moonbase.mbip_5.gas_storage_ratio }} 
+    ```
 
 Then, you can take the storage growth in bytes for a given transaction and multiply it by the gas-to-storage growth ratio to determine how many units of gas to add to the transaction. For example, if you execute a transaction that increases the storage by {{ networks.moonbase.mbip_5.example_storage }} bytes, the following calculation is used to determine the units of gas to add:
 
-```text
-Additional Gas = {{ networks.moonbase.mbip_5.example_storage }} * {{ networks.moonbase.mbip_5.gas_storage_ratio }}
-Additional Gas = {{ networks.moonbase.mbip_5.example_addtl_gas }}
-```
+=== "Moonriver"
+
+    ```text
+    Additional Gas = {{ networks.moonriver.mbip_5.example_storage }} * {{ networks.moonriver.mbip_5.gas_storage_ratio }}
+    Additional Gas = {{ networks.moonriver.mbip_5.example_addtl_gas }}
+    ```
+
+=== "Moonbase Alpha"
+
+    ```text
+    Additional Gas = {{ networks.moonbase.mbip_5.example_storage }} * {{ networks.moonbase.mbip_5.gas_storage_ratio }}
+    Additional Gas = {{ networks.moonbase.mbip_5.example_addtl_gas }}
+    ```
 
 To see how this MBIP differentiates Moonbeam from Ethereum firsthand, you can estimate the gas for two different contract interactions on both networks: one that modifies an item in the chain state and one that doesn't. For example, you can use a greeting contract that allows you to store a name and then use the name to say "Hello".
 
@@ -76,7 +120,7 @@ contract SayHello {
 }
 ```
 
-You can deploy this contract on both Moonbeam's TestNet, Moonbase Alpha, and Ethereum's TestNet, Sepolia, or feel free to access the contracts that have already been deployed to each network:
+You can deploy this contract on both Moonriver and Ethereum, or on Moonbeam's TestNet, Moonbase Alpha, and Ethereum's TestNet, Sepolia. The above contract has already been deployed to Moonbase Alpha and Sepolia. You can feel free to access these contracts at the following addresses:
 
 === "Moonbase Alpha"
 

--- a/variables.yml
+++ b/variables.yml
@@ -406,7 +406,13 @@ networks:
     min_gas_price: 1.25
     block_time: 12
     gas_block: 15,000,000
+    gas_block_numbers_only: 15000000
     gas_tx: 12,995,000
+    mbip_5:
+      block_storage_limit: 40
+      gas_storage_ratio: 366
+      example_storage: 500
+      example_addtl_gas: 183000
     node:
       cores: 8
       ram: 16


### PR DESCRIPTION
### Description

This PR expands on the MBIP-5 docs to include support for Moonriver.

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
