### PR TITLE
update moonriver candidate bond

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -584,8 +584,8 @@ networks:
       collator_reward_inflation: 20
       parachain_bond_inflation: 30
     staking:
-      min_can_stk: 10000
-      min_can_stk_wei: 10000000000000000000000
+      min_can_stk: 500
+      min_can_stk_wei: 500000000000000000000
       collator_map_bond: 100
       max_candidates: 72
       paid_out_block: 73 # Update this whenever max_candidates is changed! Always max_candidates + 1!


### PR DESCRIPTION
### Description

This PR updates the Moonriver candidate bond, which as of runtime 2600 has been decreased to 500 MOVR.
Related: https://github.com/moonbeam-foundation/moonbeam/pull/2552