### PR TITLE
bump to client v0.34.0 and switch purestake to moonbeamfoundation

### DIFF
--- a/builders/get-started/networks/moonbeam-dev.md
+++ b/builders/get-started/networks/moonbeam-dev.md
@@ -29,7 +29,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
 1. Execute the following command to download the latest Moonbeam image:
 
     ```bash
-    docker pull purestake/moonbeam:{{ networks.development.build_tag }}
+    docker pull moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
     ```
 
     The tail end of the console log should look like this:
@@ -42,7 +42,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
 
         ```bash
         docker run --rm --name {{ networks.development.container_name }} --network host \
-        purestake/moonbeam:{{ networks.development.build_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
         --dev --rpc-external
         ```
 
@@ -50,7 +50,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
 
         ```bash
         docker run --rm --name {{ networks.development.container_name }} -p 9944:9944 \
-        purestake/moonbeam:{{ networks.development.build_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
         --dev --rpc-external
         ```
 
@@ -58,7 +58,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
 
         ```bash
         docker run --rm --name {{ networks.development.container_name }} -p 9944:9944 ^
-        purestake/moonbeam:{{ networks.development.build_tag }} ^
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} ^
         --dev --rpc-external
         ```
 
@@ -75,7 +75,7 @@ For more information on some of the flags and options used in the example, check
 
 ```bash
 docker run --rm --name {{ networks.development.container_name }} \
-purestake/moonbeam \
+moonbeamfoundation/moonbeam \
 --help
 ```
 

--- a/node-operators/networks/run-a-node/docker.md
+++ b/node-operators/networks/run-a-node/docker.md
@@ -94,7 +94,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run --network="host" -v "{{ networks.moonbeam.node_directory }}:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
         --base-path=/data \
         --chain {{ networks.moonbeam.chain_spec }} \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -110,7 +110,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run --network="host" -v "{{ networks.moonriver.node_directory }}:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonriver.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonriver.parachain_release_tag }} \
         --base-path=/data \
         --chain {{ networks.moonriver.chain_spec }} \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -126,7 +126,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run --network="host" -v "{{ networks.moonbase.node_directory }}:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbase.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbase.parachain_release_tag }} \
         --base-path=/data \
         --chain {{ networks.moonbase.chain_spec }} \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -144,7 +144,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
         --base-path=/data \
         --chain moonbeam \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -159,7 +159,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonriver.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonriver.parachain_release_tag }} \
         --base-path=/data \
         --chain moonriver \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -174,7 +174,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbase.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbase.parachain_release_tag }} \
         --base-path=/data \
         --chain alphanet \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -193,7 +193,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash hl_lines="10"
         docker run --network="host" -v "{{ networks.moonbeam.node_directory }}:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
         --base-path=/data \
         --chain {{ networks.moonbeam.chain_spec }} \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -210,7 +210,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash hl_lines="9"
         docker run -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
         --base-path=/data \
         --chain moonbeam \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -230,7 +230,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash hl_lines="11"
         docker run --network="host" -v "{{ networks.moonbeam.node_directory }}:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
         --base-path=/data \
         --chain {{ networks.moonbeam.chain_spec }} \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -248,7 +248,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash hl_lines="9"
         docker run -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
         --base-path=/data \
         --chain moonbeam \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -268,7 +268,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run --network="host" -v "{{ networks.moonbeam.node_directory }}:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
         --base-path=/data \
         --chain {{ networks.moonbeam.chain_spec }} \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -284,7 +284,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run --network="host" -v "{{ networks.moonriver.node_directory }}:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonriver.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonriver.parachain_release_tag }} \
         --base-path=/data \
         --chain {{ networks.moonriver.chain_spec }} \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -300,7 +300,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run --network="host" -v "{{ networks.moonbase.node_directory }}:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbase.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbase.parachain_release_tag }} \
         --base-path=/data \
         --chain {{ networks.moonbase.chain_spec }} \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -318,7 +318,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
         --base-path=/data \
         --chain moonbeam \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -333,7 +333,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonriver.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonriver.parachain_release_tag }} \
         --base-path=/data \
         --chain moonriver \
         --name="INSERT_YOUR_NODE_NAME" \
@@ -348,7 +348,7 @@ For an overview of the flags used in the following start-up commands, plus addit
         ```bash
         docker run -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
         -u $(id -u ${USER}):$(id -g ${USER}) \
-        purestake/moonbeam:{{ networks.moonbase.parachain_release_tag }} \
+        moonbeamfoundation/moonbeam:{{ networks.moonbase.parachain_release_tag }} \
         --base-path=/data \
         --chain alphanet \
         --name="INSERT_YOUR_NODE_NAME" \

--- a/node-operators/networks/run-a-node/flags.md
+++ b/node-operators/networks/run-a-node/flags.md
@@ -69,7 +69,7 @@ For a complete list of the available flags, you can spin up your Moonbeam node w
     ```bash
     docker run --network="host" -v "{{ networks.moonbeam.node_directory }}:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
-    purestake/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
+    moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }} \
     --help
     ```
 
@@ -78,7 +78,7 @@ For a complete list of the available flags, you can spin up your Moonbeam node w
     ```bash
     docker run --network="host" -v "{{ networks.moonriver.node_directory }}:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
-    purestake/moonbeam:{{ networks.moonriver.parachain_release_tag }} \
+    moonbeamfoundation/moonbeam:{{ networks.moonriver.parachain_release_tag }} \
     --help
     ```
 
@@ -87,7 +87,7 @@ For a complete list of the available flags, you can spin up your Moonbeam node w
     ```bash
     docker run --network="host" -v "{{ networks.moonbase.node_directory }}:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
-    purestake/moonbeam:{{ networks.moonbase.parachain_release_tag }} \
+    moonbeamfoundation/moonbeam:{{ networks.moonbase.parachain_release_tag }} \
     --help
     ```
 

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -9,7 +9,7 @@ description: Learn how to leverage Geth's Debug and Txpool APIs, and OpenEthereu
 
 Geth's `debug` and `txpool` APIs and OpenEthereum's `trace` module provide non-standard RPC methods for getting a deeper insight into transaction processing. As part of Moonbeam's goal of providing a seamless Ethereum experience for developers, there is support for some of these non-standard RPC methods. Supporting these RPC methods is an important milestone because many projects, such as [The Graph](https://thegraph.com/){target=_blank}, rely on them to index blockchain data.
 
-To use the supported RPC methods, you need to run a tracing node, which is slightly different than running a full node. There is a different Docker image, called `purestake/moonbeam-tracing` that needs to be used for tracing. Additional flags will also need to be used to tell the node which of the non-standard features to support.
+To use the supported RPC methods, you need to run a tracing node, which is slightly different than running a full node. There is a different Docker image, called `moonbeamfoundation/moonbeam-tracing` that needs to be used for tracing. Additional flags will also need to be used to tell the node which of the non-standard features to support.
 
 This guide will show you how to get started running a tracing node on Moonbeam with the `debug`, `txpool`, and `tracing` flags enabled.
 
@@ -87,7 +87,7 @@ Before getting started, you'll need to set the necessary permissions either for 
     sudo chown -R $(id -u):$(id -g) {{ networks.moonbase.node_directory }}
     ```
 
-Instead of the standard `purestake/moonbeam` docker image, you will need to use `purestake/moonbeam-tracing` image. The latest supported version can be found on the [Docker Hub for the `moonbeam-tracing` image](https://hub.docker.com/r/purestake/moonbeam-tracing/tags).
+Instead of the standard `moonbeamfoundation/moonbeam` docker image, you will need to use `moonbeamfoundation/moonbeam-tracing` image. The latest supported version can be found on the [Docker Hub for the `moonbeam-tracing` image](https://hub.docker.com/r/moonbeamfoundation/moonbeam-tracing/tags){target=_blank}.
 
 Now, execute the docker run command. Note that you have to:
 

--- a/tutorials/integrations/local-subsquid.md
+++ b/tutorials/integrations/local-subsquid.md
@@ -43,7 +43,7 @@ To spin up a development node, which will pull the latest Docker image for Moonb
 
     ```bash
     docker run --rm --name {{ networks.development.container_name }} --network host \
-    purestake/moonbeam:{{ networks.development.build_tag }} \
+    moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
     --dev --sealing 4000 --rpc-external
     ```
 
@@ -51,7 +51,7 @@ To spin up a development node, which will pull the latest Docker image for Moonb
 
     ```bash
     docker run --rm --name {{ networks.development.container_name }} -p 9944:9944 \
-    purestake/moonbeam:{{ networks.development.build_tag }} \
+    moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
     --dev --sealing 4000 --rpc-external
     ```
 
@@ -59,7 +59,7 @@ To spin up a development node, which will pull the latest Docker image for Moonb
 
     ```bash
     docker run --rm --name {{ networks.development.container_name }} -p 9944:9944 ^
-    purestake/moonbeam:{{ networks.development.build_tag }} ^
+    moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} ^
     --dev --sealing 4000 --rpc-external
     ```
 

--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
     build_tag: v0.34.0
-    tracing_tag: purestake/moonbeam-tracing:v0.34.0-2601-latest
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.34.0-2601-latest
     rpc_url: http://127.0.0.1:9944
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -18,7 +18,7 @@ networks:
     spec_version: runtime-2500
     parachain_release_tag: v0.34.0 # must be in this exact format for links to work
     parachain_sha256sum: 0ded3fe4095b5848c3de7483889c17a507220435ad2e21bb9e460a3f1e3eff1c
-    tracing_tag: purestake/moonbeam-tracing:v0.34.0-2601-latest
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.34.0-2601-latest
     gas_block: 15,000,000
     gas_block_numbers_only: 15000000
     gas_tx: 12,995,000
@@ -394,7 +394,7 @@ networks:
     node_directory: /var/lib/moonriver-data
     parachain_release_tag: v0.34.0
     parachain_sha256sum: 0ded3fe4095b5848c3de7483889c17a507220435ad2e21bb9e460a3f1e3eff1c
-    tracing_tag: purestake/moonbeam-tracing:v0.34.0-2601-latest
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.34.0-2601-latest
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     spec_version: runtime-2403
@@ -731,7 +731,7 @@ networks:
     node_directory: /var/lib/moonbeam-data
     parachain_release_tag: v0.34.0
     parachain_sha256sum: 0ded3fe4095b5848c3de7483889c17a507220435ad2e21bb9e460a3f1e3eff1c
-    tracing_tag: purestake/moonbeam-tracing:v0.34.0-2601-latest
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.34.0-2601-latest
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     spec_version: runtime-2403

--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
-    build_tag: v0.32.2
-    tracing_tag: purestake/moonbeam-tracing:v0.32.2-2403-latest
+    build_tag: v0.34.0
+    tracing_tag: purestake/moonbeam-tracing:v0.34.0-2601-latest
     rpc_url: http://127.0.0.1:9944
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -16,9 +16,9 @@ networks:
     chain_spec: alphanet
     block_explorer: https://moonbase.moonscan.io/
     spec_version: runtime-2500
-    parachain_release_tag: v0.33.0 # must be in this exact format for links to work
-    parachain_sha256sum: 1a31ee40cc2e320a009ee687624c53bb51cf65c69a0409b018a5378d5231eaf7
-    tracing_tag: purestake/moonbeam-tracing:v0.33.0-2500-latest
+    parachain_release_tag: v0.34.0 # must be in this exact format for links to work
+    parachain_sha256sum: 0ded3fe4095b5848c3de7483889c17a507220435ad2e21bb9e460a3f1e3eff1c
+    tracing_tag: purestake/moonbeam-tracing:v0.34.0-2601-latest
     gas_block: 15,000,000
     gas_block_numbers_only: 15000000
     gas_tx: 12,995,000
@@ -392,9 +392,9 @@ networks:
     chain_id: 1285
     hex_chain_id: '0x505'
     node_directory: /var/lib/moonriver-data
-    parachain_release_tag: v0.33.0
-    parachain_sha256sum: 1a31ee40cc2e320a009ee687624c53bb51cf65c69a0409b018a5378d5231eaf7
-    tracing_tag: purestake/moonbeam-tracing:v0.33.0-2500-latest
+    parachain_release_tag: v0.34.0
+    parachain_sha256sum: 0ded3fe4095b5848c3de7483889c17a507220435ad2e21bb9e460a3f1e3eff1c
+    tracing_tag: purestake/moonbeam-tracing:v0.34.0-2601-latest
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     spec_version: runtime-2403
@@ -729,9 +729,9 @@ networks:
     chain_id: 1284
     hex_chain_id: '0x504'
     node_directory: /var/lib/moonbeam-data
-    parachain_release_tag: v0.33.0
-    parachain_sha256sum: 1a31ee40cc2e320a009ee687624c53bb51cf65c69a0409b018a5378d5231eaf7
-    tracing_tag: purestake/moonbeam-tracing:v0.33.0-2500-latest
+    parachain_release_tag: v0.34.0
+    parachain_sha256sum: 0ded3fe4095b5848c3de7483889c17a507220435ad2e21bb9e460a3f1e3eff1c
+    tracing_tag: purestake/moonbeam-tracing:v0.34.0-2601-latest
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     spec_version: runtime-2403


### PR DESCRIPTION
### Description

This PR bumps the client version to v0.34.0 and it also switches docker images from `purestake` to `moonbeamfoundation`

Goes with CN PR: https://github.com/moonbeam-foundation/moonbeam-docs-cn/pull/361
