### PR TITLE
Misc changes: Add more XCM SDK examples, add Web3.js common errors, and a few quick fixes

### DIFF
--- a/.snippets/code/builders/build/eth-api/libraries/web3-js/deploy.js
+++ b/.snippets/code/builders/build/eth-api/libraries/web3-js/deploy.js
@@ -2,7 +2,7 @@
 const { Web3 } = require('web3');
 const contractFile = require('./compile');
 
-// 2. Add the Web3 provider logic here:
+// 2. Add the Web3 provider logic
 const providerRPC = {
   development: 'http://localhost:9944',
   moonbase: 'https://rpc.api.moonbase.moonbeam.network',
@@ -26,13 +26,13 @@ const deploy = async () => {
   // 6. Create contract instance
   const incrementer = new web3.eth.Contract(abi);
 
-  // 7. Create constructor tx
+  // 7. Create constructor transaction
   const incrementerTx = incrementer.deploy({
     data: bytecode,
     arguments: [5],
   });
 
-  // 8. Sign transacation and send
+  // 8. Sign transaction with PK
   const createTransaction = await web3.eth.accounts.signTransaction(
     {
       data: incrementerTx.encodeABI(),
@@ -43,7 +43,7 @@ const deploy = async () => {
     accountFrom.privateKey
   );
 
-  // 9. Send tx and wait for receipt
+  // 9. Send transaction and wait for receipt
   const createReceipt = await web3.eth.sendSignedTransaction(
     createTransaction.rawTransaction
   );

--- a/.snippets/code/builders/build/eth-api/libraries/web3-js/get.js
+++ b/.snippets/code/builders/build/eth-api/libraries/web3-js/get.js
@@ -1,8 +1,8 @@
-// 1. Import Web3js and the contract abi
+// 1. Import Web3js and the contract ABI
 const { Web3 } = require('web3');
 const { abi } = require('./compile');
 
-// 2. Add the Web3 provider logic here:
+// 2. Add the Web3 provider logic
 const providerRPC = {
   development: 'http://localhost:9944',
   moonbase: 'https://rpc.api.moonbase.moonbeam.network',

--- a/.snippets/code/builders/build/eth-api/libraries/web3-js/increment.js
+++ b/.snippets/code/builders/build/eth-api/libraries/web3-js/increment.js
@@ -1,13 +1,13 @@
-// 1. Import Web3js and the contract abi
+// 1. Import Web3js and the contract ABI
 const { Web3 } = require('web3');
 const { abi } = require('./compile');
 
-// 2. Add the Web3 provider logic here:
+// 2. Add the Web3 provider logic
 const providerRPC = {
   development: 'http://localhost:9944',
   moonbase: 'https://rpc.api.moonbase.moonbeam.network',
 };
-const web3 = new Web3(providerRPC.moonbase); //Change to correct network
+const web3 = new Web3(providerRPC.moonbase); // Change to correct network
 
 // 3. Create variables
 const accountFrom = {
@@ -20,7 +20,7 @@ const _value = 3;
 // 4. Create contract instance
 const incrementer = new web3.eth.Contract(abi, contractAddress);
 
-// 5. Build increment tx
+// 5. Build increment transaction
 const incrementTx = incrementer.methods.increment(_value);
 
 // 6. Create increment function
@@ -29,7 +29,7 @@ const increment = async () => {
     `Calling the increment by ${_value} function in contract at address: ${contractAddress}`
   );
 
-  // 7. Prepare and Sign Tx with PK
+  // 7. Sign transaction with PK
   const createTransaction = await web3.eth.accounts.signTransaction(
     {
       to: contractAddress,
@@ -41,7 +41,7 @@ const increment = async () => {
     accountFrom.privateKey
   );
 
-  // 8. Send Tx and Wait for Receipt
+  // 8. Send transaction and wait for receipt
   const createReceipt = await web3.eth.sendSignedTransaction(
     createTransaction.rawTransaction
   );

--- a/.snippets/code/builders/build/eth-api/libraries/web3-js/reset.js
+++ b/.snippets/code/builders/build/eth-api/libraries/web3-js/reset.js
@@ -1,8 +1,8 @@
-// 1. Import Web3js and the contract abi
+// 1. Import Web3js and the contract ABI
 const { Web3 } = require('web3');
 const { abi } = require('./compile');
 
-// 2. Add the Web3 provider logic here:
+// 2. Add the Web3 provider logic
 const providerRPC = {
   development: 'http://localhost:9944',
   moonbase: 'https://rpc.api.moonbase.moonbeam.network',
@@ -19,14 +19,14 @@ const contractAddress = 'INSERT_CONTRACT_ADDRESS';
 // 4. Create contract instance
 const incrementer = new web3.eth.Contract(abi, contractAddress);
 
-// 5. Build reset tx
+// 5. Build reset transaction
 const resetTx = incrementer.methods.reset();
 
 // 6. Create reset function
 const reset = async () => {
   console.log(`Calling the reset function in contract at address: ${contractAddress}`);
 
-  // 7. Prepare and sign tx with PK
+  // 7. Sign transaction with PK
   const createTransaction = await web3.eth.accounts.signTransaction(
     {
       to: contractAddress,
@@ -38,7 +38,7 @@ const reset = async () => {
     accountFrom.privateKey
   );
 
-  // 8. Send tx and wait for receipt
+  // 8. Send transaction and wait for receipt
   const createReceipt = await web3.eth.sendSignedTransaction(createTransaction.rawTransaction);
   console.log(`Tx successful with hash: ${createReceipt.transactionHash}`);
 };

--- a/.snippets/code/builders/build/eth-api/libraries/web3-js/transaction.js
+++ b/.snippets/code/builders/build/eth-api/libraries/web3-js/transaction.js
@@ -1,6 +1,6 @@
 const { Web3 } = require('web3');
 
-// 1. Add the Web3 provider logic here:
+// 1. Add the Web3 provider logic
 const providerRPC = {
   development: 'http://localhost:9944',
   moonbase: 'https://rpc.api.moonbase.moonbeam.network',
@@ -20,7 +20,7 @@ const send = async () => {
     `Attempting to send transaction from ${accountFrom.address} to ${addressTo}`
   );
 
-  // 4. Prepare and sign tx with PK
+  // 4. Sign transaction with PK
   const createTransaction = await web3.eth.accounts.signTransaction(
     {
       gas: 21000,
@@ -32,7 +32,7 @@ const send = async () => {
     accountFrom.privateKey
   );
 
-  // 5. Send tx and wait for receipt
+  // 5. Send transaction and wait for receipt
   const createReceipt = await web3.eth.sendSignedTransaction(
     createTransaction.rawTransaction
   );

--- a/.snippets/text/_common/assumes-mac-or-ubuntu-env.md
+++ b/.snippets/text/_common/assumes-mac-or-ubuntu-env.md
@@ -1,1 +1,1 @@
-The examples in this guide assumes you have a MacOS or Ubuntu 18.04-based environment and will need to be adapted accordingly for Windows.
+The examples in this guide assume you have a MacOS or Ubuntu 18.04-based environment and will need to be adapted accordingly for Windows.

--- a/.snippets/text/learn/features/governance/approval-support-definitions.md
+++ b/.snippets/text/learn/features/governance/approval-support-definitions.md
@@ -1,2 +1,2 @@
- - **Approval** — minimum "Aye" votes as a percentage of overall Conviction-weighted votes needed for an approval
- - **Support** — minimum number of "Aye" votes, not taking into consideration Conviction-weighted votes, needed as a percent of the total supply needed for an approval
+ - **Approval** — minimum "Aye" votes as a percentage of overall Conviction-weighted votes needed for approval
+ - **Support** — minimum number of "Aye" votes, not taking into consideration Conviction-weighted votes, needed as a percent of the total supply needed for approval

--- a/.snippets/text/learn/features/governance/delegation-definitions.md
+++ b/.snippets/text/learn/features/governance/delegation-definitions.md
@@ -1,2 +1,2 @@
- - **Vote Delegation** — a voter can give their voting power, including Conviction voting, to another token holder (delegate) who may be more knowledgable and able to make specific decisions
+ - **Vote Delegation** — a voter can give their voting power, including Conviction voting, to another token holder (delegate), who may be more knowledgeable and able to make specific decisions
  - **Multirole Delegation** — the ability to delegate voting power on a Track-by-Track basis, where a token holder can specify different delegates for each Track

--- a/.snippets/text/learn/features/governance/vote-conviction-definitions.md
+++ b/.snippets/text/learn/features/governance/vote-conviction-definitions.md
@@ -1,5 +1,5 @@
  - **Voting** — a tool used by token holders to either approve ("Aye") or reject ("Nay") a proposal. The weight a vote has is defined by two factors: the number of tokens locked and lock duration (called Conviction)
-    - **Conviction** — the time that token holders voluntarily lock their tokens when voting: the longer they are locked, the more weight their vote has
+    - **Conviction** — the time that token holders voluntarily lock their tokens when voting; the longer they are locked, the more weight their vote has
     - **Lock balance** — the number of tokens that a user commits to a vote (note, this is not the same as a user's total account balance)
 
-    Moonbeam uses a concept of voluntary locking that allows token holders to increase their voting power by locking tokens for a longer period of time. Specifying no Lock Period means a user's vote is valued at 10% of their lock balance. Additional voting power can be achieved by specifying a greater conviction. For each increase in Conviction (vote multiplier), the Lock Periods double.
+    Moonbeam uses the concept of voluntary locking, which allows token holders to increase their voting power by locking tokens for a longer period of time. Specifying no Lock Period means a user's vote is valued at 10% of their lock balance. Specifying a greater Conviction increases voting power. For each increase in Conviction (vote multiplier), the Lock Periods double

--- a/builders/build/eth-api/libraries/web3js.md
+++ b/builders/build/eth-api/libraries/web3js.md
@@ -25,7 +25,7 @@ For the examples in this guide, you will need to have the following:
 
 ## Installing Web3.js {: #install-web3js }
 
-To get started, you'll need to start a basic JavaScript project. First, create a directory to store all of the files you'll be creating throughout this guide and initialize the project with the following command:
+To get started, you'll need to start a basic JavaScript project. First, create a directory to store all of the files you'll be creating throughout this guide, and initialize the project with the following command:
 
 ```bash
 mkdir web3-examples && cd web3-examples && npm init --y
@@ -88,7 +88,7 @@ The simplest way to get started with each of the networks is as follows:
     const web3 = new Web3('{{ networks.development.rpc_url }}');
     ```
 
-Save this code snippet as you'll need it for the scripts that are used in the following sections.
+Save this code snippet, as you'll need it for the scripts that are used in the following sections.
 
 ## Send a Transaction {: #send-a-transaction }
 
@@ -108,12 +108,12 @@ Next, you will create the script for this file and complete the following steps:
 
 1. [Set up the Web3 provider](#setup-web3-with-moonbeam)
 2. Define the `addressFrom` and `addressTo` variables
-3. Create the asynchronous `balances` function which wraps the `web3.eth.getBalance` method
+3. Create the asynchronous `balances` function, which wraps the `web3.eth.getBalance` method
 4. Use the `web3.eth.getBalance` function to fetch the balances for the `addressFrom` and `addressTo` addresses. You can also leverage the `web3.utils.fromWei` function to transform the balance into a more readable number in DEV
 5. Lastly, run the `balances` function
 
 ```js
-// 1. Add the Web3 provider logic here:
+// 1. Add the Web3 provider logic
 // {...}
 
 // 2. Create address variables
@@ -156,7 +156,7 @@ If successful, the balances for the origin and receiving address will be display
 
 ### Send Transaction Script {: #send-transaction-script }
 
-You'll only need one file for executing a transaction between accounts. For this example, you'll be transferring 1 DEV token from an origin address (from which you hold the private key) to another address. To get started, you can create a `transaction.js` file by running:
+You'll only need one file to execute a transaction between accounts. For this example, you'll be transferring 1 DEV token from an origin address (from which you hold the private key) to another address. To get started, you can create a `transaction.js` file by running:
 
 ```bash
 touch transaction.js
@@ -166,13 +166,13 @@ Next, you will create the script for this file and complete the following steps:
 
 1. [Set up the Web3 provider](#setup-web3-with-moonbeam)
 2. Define the `accountFrom`, including the `privateKey`, and the `addressTo` variables. The private key is required to create a wallet instance. **Note: This is for example purposes only. Never store your private keys in a JavaScript file**
-3. Create the asynchronous `send` function which wraps the transaction object and the sign and send transaction functions
+3. Create the asynchronous `send` function, which wraps the transaction object, and the sign and send transaction functions
 4. Create and sign the transaction using the `web3.eth.accounts.signTransaction` function. Pass in the `gas`, `addressTo`, `value`, `gasPrice`, and `nonce` for the transaction along with the sender's `privateKey`
 5. Send the signed transaction using the `web3.eth.sendSignedTransaction` method and pass in the raw transaction. Then use `await` to wait until the transaction is processed and the transaction receipt is returned
 6. Lastly, run the `send` function
 
 ```js
-// 1. Add the Web3 provider logic here:
+// 1. Add the Web3 provider logic
 // {...}
 
 // 2. Create account variables
@@ -188,7 +188,7 @@ const send = async () => {
     `Attempting to send transaction from ${accountFrom.address} to ${addressTo}`
   );
 
-  // 4. Sign tx with PK
+  // 4. Sign transaction with PK
   const createTransaction = await web3.eth.accounts.signTransaction(
     {
       gas: 21000,
@@ -200,7 +200,7 @@ const send = async () => {
     accountFrom.privateKey
   );
 
-  // 5. Send tx and wait for receipt
+  // 5. Send transaction and wait for receipt
   const createReceipt = await web3.eth.sendSignedTransaction(
     createTransaction.rawTransaction
   );
@@ -225,7 +225,7 @@ To run the script, you can run the following command in your terminal:
 node transaction.js
 ```
 
-If the transaction was succesful, in your terminal you'll see the transaction hash has been printed out.
+If the transaction was successful, in your terminal, you'll see the transaction hash has been printed out.
 
 You can also use the `balances.js` script to check that the balances for the origin and receiving accounts have changed. The entire workflow would look like this:
 
@@ -289,7 +289,7 @@ Next, you will create the script for this file and complete the following steps:
 // 1. Import the contract file
 const contractFile = require('./compile');
 
-// 2. Add the Web3 provider logic here:
+// 2. Add the Web3 provider logic
 // {...}
 
 // 3. Create address variables
@@ -309,13 +309,13 @@ const deploy = async () => {
   // 6. Create contract instance
   const incrementer = new web3.eth.Contract(abi);
 
-  // 7. Create constructor tx
+  // 7. Create constructor transaction
   const incrementerTx = incrementer.deploy({
     data: bytecode,
     arguments: [5],
   });
 
-  // 8. Sign transacation and send
+  // 8. Sign transaction with PK
   const createTransaction = await web3.eth.accounts.signTransaction(
     {
       data: incrementerTx.encodeABI(),
@@ -326,7 +326,7 @@ const deploy = async () => {
     accountFrom.privateKey
   );
 
-  // 9. Send tx and wait for receipt
+  // 9. Send transaction and wait for receipt
   const createReceipt = await web3.eth.sendSignedTransaction(
     createTransaction.rawTransaction
   );
@@ -355,7 +355,7 @@ If successful, the contract's address will be displayed in the terminal.
 
 ### Read Contract Data (Call Methods) {: #read-contract-data }
 
-Call methods are the type of interaction that don't modify the contract's storage (change variables), meaning no transaction needs to be sent. They simply read various storage variables of the deployed contract.
+Call methods are the type of interaction that doesn't modify the contract's storage (change variables), meaning no transaction needs to be sent. They simply read various storage variables of the deployed contract.
 
 To get started, you can create a file and name it `get.js`:
 
@@ -370,14 +370,14 @@ Then you can take the following steps to create the script:
 3. Create the `contractAddress` variable using the address of the deployed contract
 4. Create an instance of the contract using the `web3.eth.Contract` function and passing in the `abi` and  `contractAddress`
 5. Create the asynchronous `get` function
-6. Use the contract instance to call one of the contract's methods and pass in any inputs if necessary. For this example, you will call the `number` method which doesn't require any inputs. You can use `await` which will return the value requested once the request promise resolves
+6. Use the contract instance to call one of the contract's methods and pass in any inputs if necessary. For this example, you will call the `number` method which doesn't require any inputs. You can use `await`, which will return the value requested once the request promise resolves
 7. Lastly, call the `get` function
 
 ```js
-// 1. Import the contract abi
+// 1. Import the contract ABI
 const { abi } = require('./compile');
 
-// 2. Add the Web3 provider logic here:
+// 2. Add the Web3 provider logic
 // {...}
 
 // 3. Create address variables
@@ -416,7 +416,7 @@ If successful, the value will be displayed in the terminal.
 
 ### Interact with Contract (Send Methods) {: #interact-with-contract }
 
-Send methods are the type of interaction that modify the contract's storage (change variables), meaning a transaction needs to be signed and sent. In this section, you'll create two scripts: one to increment and one to reset the incrementer. To get started, you can create a file for each script and name them `increment.js` and `reset.js`:
+Send methods are the type of interaction that modifies the contract's storage (change variables), meaning a transaction needs to be signed and sent. In this section, you'll create two scripts: one to increment and one to reset the incrementer. To get started, you can create a file for each script and name them `increment.js` and `reset.js`:
 
 ```bash
 touch increment.js reset.js
@@ -435,10 +435,10 @@ Open the `increment.js` file and take the following steps to create the script:
 9. Lastly, call the `increment` function
 
 ```js
-// 1. Import the contract abi
+// 1. Import the contract ABI
 const { abi } = require('./compile');
 
-// 2. Add the Web3 provider logic here:
+// 2. Add the Web3 provider logic
 // {...}
 
 // 3. Create variables
@@ -452,7 +452,7 @@ const _value = 3;
 // 4. Create contract instance
 const incrementer = new web3.eth.Contract(abi, contractAddress);
 
-// 5. Build increment tx
+// 5. Build the increment transaction
 const incrementTx = incrementer.methods.increment(_value);
 
 // 6. Create increment function
@@ -461,7 +461,7 @@ const increment = async () => {
     `Calling the increment by ${_value} function in contract at address: ${contractAddress}`
   );
 
-  // 7. Prepare and Sign Tx with PK
+  // 7. Sign transaction with PK
   const createTransaction = await web3.eth.accounts.signTransaction(
     {
       to: contractAddress,
@@ -473,7 +473,7 @@ const increment = async () => {
     accountFrom.privateKey
   );
 
-  // 8. Send Tx and Wait for Receipt
+  // 8. Send transaction and wait for receipt
   const createReceipt = await web3.eth.sendSignedTransaction(
     createTransaction.rawTransaction
   );
@@ -500,7 +500,7 @@ If successful, the transaction hash will be displayed in the terminal. You can u
 
 ![Increment Contract Web3js](/images/builders/build/eth-api/libraries/web3js/web3js-3.png)
 
-Next you can open the `reset.js` file and take the following steps to create the script:
+Next, you can open the `reset.js` file and take the following steps to create the script:
 
 1. Import the `abi` from the `compile.js` file
 2. [Set up the Web3 provider](#setup-web3-with-moonbeam)
@@ -513,10 +513,10 @@ Next you can open the `reset.js` file and take the following steps to create the
 9. Lastly, call the `reset` function
 
 ```js
-// 1. Import the contract abi
+// 1. Import the contract ABI
 const { abi } = require('./compile');
 
-// 2. Add the Web3 provider logic here:
+// 2. Add the Web3 provider logic
 // {...}
 
 // 3. Create variables
@@ -526,10 +526,10 @@ const accountFrom = {
 };
 const contractAddress = 'INSERT_CONTRACT_ADDRESS';
 
-// 4. Create Contract Instance
+// 4. Create a contract instance
 const incrementer = new web3.eth.Contract(abi, contractAddress);
 
-// 5. Build reset tx
+// 5. Build reset transaction
 const resetTx = incrementer.methods.reset();
 
 // 6. Create reset function
@@ -538,7 +538,7 @@ const reset = async () => {
     `Calling the reset function in contract at address: ${contractAddress}`
   );
 
-  // 7. Sign tx with PK
+  // 7. Sign transaction with PK
   const createTransaction = await web3.eth.accounts.signTransaction(
     {
       to: contractAddress,
@@ -550,7 +550,7 @@ const reset = async () => {
     accountFrom.privateKey
   );
 
-  // 8. Send tx and wait for receipt
+  // 8. Send transaction and wait for receipt
   const createReceipt = await web3.eth.sendSignedTransaction(
     createTransaction.rawTransaction
   );

--- a/builders/build/eth-api/libraries/web3js.md
+++ b/builders/build/eth-api/libraries/web3js.md
@@ -231,6 +231,26 @@ You can also use the `balances.js` script to check that the balances for the ori
 
 ![Send Tx Web3js](/images/builders/build/eth-api/libraries/web3js/web3js-1.png)
 
+### Common Errors When Sending Transactions {: #common-errors }
+
+When sending a transaction with Web3.js, it is important that you have all of the required data for the transaction. You'll need to provide the `from` address or the `nonce` of the sender, the `gas` or `gasLimit`, and the `gasPrice`.
+
+If you do not specify the `from` address or the `nonce` of the sender, you may receive the following error:
+
+```bash
+UnableToPopulateNonceError: Invalid value given "UnableToPopulateNonceError". Error: unable to populate nonce, no from address available.
+```
+
+To fix this, simply add either the `from` or `nonce` field to the transaction object.
+
+If you do not specify the gas correctly, you may receive the following error:
+
+```bash
+MissingGasError: Invalid value given "gas: 0x5208, gasPrice: undefined, maxPriorityFeePerGas: undefined, maxFeePerGas: undefined". Error: "gas" is missing.
+```
+
+To resolve this error, you'll need to make sure that you've provided a `gasPrice` for the transaction. You can use `await web3.eth.getGasPrice()` to programmatically get this value.
+
 ## Deploy a Contract {: #deploy-a-contract }
 
 --8<-- 'text/builders/build/eth-api/libraries/contract.md'

--- a/builders/interoperability/xcm/xcm-sdk/v1/xcm-sdk.md
+++ b/builders/interoperability/xcm/xcm-sdk/v1/xcm-sdk.md
@@ -232,6 +232,68 @@ const pair = keyring.createFromUri(privateKey);
 !!! note
     In the above `INSERT_PRIVATE_KEY` field, you can specify a seed phrase instead of a private key.
 
+## Get Asset and Chain Data {: #asset-chain-data }
+
+You can use any of the following code examples to retrieve information on the supported assets and the chains that support these assets.
+
+### Get List of Supported Assets {: #get-list-of-supported-assets }
+
+To get a list of all of the assets supported by the XCM SDK, you can instantiate the XCM SDK and call the `assets` function.
+
+```js
+import { Sdk } from '@moonbeam-network/xcm-sdk';
+
+const sdkInstance = new Sdk();
+const assets = sdkInstance.assets();
+
+console.log('The supported assets are as follows:');
+assets.assets.forEach((asset) => {
+  console.log(`- ${asset.originSymbol}`);
+});
+```
+
+### Get List of Supported Assets by Ecosystem {: #get-supported-assets-by-ecosystem }
+
+To get a list of the supported assets for a particular ecosystem, you can pass in the ecosystem name: `polkadot`, `kusama`, or `alphanet-relay`. For example, the following snippet will get all of the Polkadot assets supported:
+
+```js
+import { Sdk } from '@moonbeam-network/xcm-sdk';
+
+const sdkInstance = new Sdk();
+const assets = sdkInstance.assets('polkadot');
+
+console.log('The supported assets within the Polkadot ecosystem are as follows:');
+assets.assets.forEach((asset) => {
+  console.log(`- ${asset.originSymbol}`);
+});
+```
+
+### Get List of Supported Chains by Asset {: #get-list-of-supported-assets-by-chain }
+
+To get a list of the supported source and destination chains for a given asset, you can use the following code snippet, which logs the supported chains by asset for all of the supported assets in the Polkadot ecosystem:
+
+```js
+import { Sdk } from '@moonbeam-network/xcm-sdk';
+
+const sdkInstance = new Sdk();
+const assets = sdkInstance.assets('polkadot');
+
+assets.assets.forEach((asset) => {
+  const { sourceChains, source } = assets.asset(asset);
+  console.log(`You can send ${asset.originSymbol}...`);
+  if (sourceChains.length > 1) {
+    sourceChains.forEach((sourceChain) => {
+      const { destinationChains } = source(sourceChain);
+      if (destinationChains.length > 0) {
+        destinationChains.forEach((destination) => {
+          console.log(`- From ${source.name} to ${destination.name}`);
+        });
+      }
+    });
+  }
+});
+```
+
 ## Build XCM Transfer Data {: #build-xcm-transfer-data }
 
 In order to transfer an asset from one chain to another, you'll need to first build the transfer data, which defines the asset to be transferred, the source chain and address, the destination chain and address, and the associated signer for the transaction. Building the transfer data is the first step; in the next section, you'll learn how to use the transfer data to actually transfer the asset.

--- a/node-operators/networks/run-a-node/flags.md
+++ b/node-operators/networks/run-a-node/flags.md
@@ -41,7 +41,7 @@ This guide will cover some of the most common flags and show you how to access a
 - **`--runtime-cache-size 64`** - configures the number of different runtime versions preserved in the in-memory cache to 64
 - **`--eth-log-block-cache`** - size in bytes the LRU cache for block data is limited to use. This flag mostly pertains to RPC providers. The default is `300000000`
 - **`--eth-statuses-cache`** - size in bytes the LRU cache for transaction statuses data is limited to use. This flag mostly pertains to RPC providers. The default is `300000000`
-- **--sync** - sets the blockchain syncing mode, which can allow for the blockchain to be synced faster. The available options are:
+- **`--sync`** - sets the blockchain syncing mode, which can allow for the blockchain to be synced faster. The available options are:
     - **`full`** - downloads and validates the full blockchain history
     - **`fast`** - downloads blocks without executing them and downloads the latest state with proofs
     - **`fast-unsafe`** - same as `fast`, but skips downloading the state proofs

--- a/tokens/governance/voting.md
+++ b/tokens/governance/voting.md
@@ -11,7 +11,7 @@ Referenda are simple, inclusive, and stake-based voting schemes. Each referendum
 
 Token holders can vote on referenda using their own tokens, including those that are locked in staking. The weight of a vote is defined by two factors: the number of tokens locked and the lock duration (called Conviction). This is to ensure that there is an economic buy-in to prevent vote-selling. Consequently, the longer you are willing to lock your tokens, the stronger your vote will be weighted. You also have the option of not locking tokens at all, but the vote weight is drastically reduced.
 
-In Moonbeam, users will be able to create and vote on proposals using their H160 address and private key, that is, their regular Ethereum account!
+In Moonbeam, users are able to create and vote on proposals using their H160 address and private key, that is, their regular Ethereum account!
 
 This guide will outline the process, with step-by-step instructions, of how to vote on referenda in Governance v2: OpenGov. This guide will show you how to vote on Moonbase Alpha, but it can be easily adapted for Moonbeam and Moonriver.
 
@@ -48,7 +48,7 @@ Some of the key parameters for this guide are the following:
 
 --8<-- 'text/learn/features/governance/lead-in-definitions.md'
 
- - **Decide Period** - token holders continue to vote on the referendum. If a referendum does not pass by the end of the period, it will be rejected and the Decision Deposit will be refunded
+ - **Decide Period** - token holders continue to vote on the referendum. If a referendum does not pass by the end of the period, it will be rejected, and the Decision Deposit will be refunded
  - **Confirm Period** - a period of time within the Decide Period where the referendum needs to have maintained enough Approval and Support to be approved and move to the Enactment Period
  - **Enactment Period** - a specified time, which is defined at the time the proposal was created, that meets at least the minimum amount of time that an approved referendum waits before it can be dispatched
 
@@ -58,25 +58,25 @@ For an overview of the Track-specific parameters such as the length of the Decid
 
 ## Roadmap of a Proposal {: #roadmap-of-a-proposal }
 
-This guide will cover how to vote on public referenda, as seen in the steps highlighted in the proposal roadmap diagram below. In addition to learning how to vote on referenda, you'll learn how the proposal progresses through the Lead-in Period, the Decide and Confirm Period, and the Enactment Period.
+This guide will cover how to vote on public referenda, as seen in the steps highlighted in the proposal roadmap diagram below. In addition to learning how to vote on referenda, you'll also learn how the proposal progresses through the Lead-in Period, the Decide and Confirm Period, and the Enactment Period.
 
-You can find a full explanation of the [happy path for a OpenGov proposal on the Governance overview page](/learn/features/governance/#roadmap-of-a-proposal-v2){target=_blank}.
+You can find a full explanation of the [happy path for an OpenGov proposal on the Governance overview page](/learn/features/governance/#roadmap-of-a-proposal-v2){target=_blank}.
 
 ![Proposal Roadmap](/images/tokens/governance/voting/proposal-roadmap.png)
 
 ## Forum Discussion {: #forum-discussion}
 
-A vote on a democracy referenda is a binary outcome. However, a token holder's opinion is often more nuanced than yes/no, which is why it's strongly recommend that you preface any proposal with a post on [Moonbeam's Community Forum](https://forum.moonbeam.foundation/){target=_blank}.
+A vote on a democracy referendum is a binary outcome. However, a token holder's opinion is often more nuanced than yes or no, which is why it's strongly recommended that you preface any proposal with a post on [Moonbeam's Community Forum](https://forum.moonbeam.foundation/){target=_blank}.
 
-The forum serves the critical role of providing a platform for discussion and allowing proposers to receive feedback from the community prior to an on-chain action. Creating a post on the forum is quick and easy as shown in the [Using the Moonbeam Community Forum](https://moonbeam.network/blog/using-moonbeam-community-forum/){target=_blank} guide. There are categories corresponding to each type of proposal, including democracy, treasury, and grant proposals. While this step is optional, explaining the details of the proposal and following up with any questions raised may increase the chances of the initiative being accepted and subsequently passed by the community.
+The forum serves the critical role of providing a platform for discussion and allowing proposers to receive feedback from the community prior to an on-chain action. Creating a post on the forum is quick and easy, as shown in the [Using the Moonbeam Community Forum](https://moonbeam.network/blog/using-moonbeam-community-forum/){target=_blank} guide. There are categories corresponding to each type of proposal, including democracy, treasury, and grant proposals. While this step is optional, explaining the details of the proposal and following up with any questions raised may increase the chances of the initiative being accepted and subsequently passed by the community.
 
 ![Moonbeam's Community Forum home](/images/tokens/governance/voting/vote-1.png)
 
 ## Voting on a Referendum {: #voting-on-a-referendum }
 
-This section goes over the process of voting on public referendum in OpenGov (Governance v2) on Moonbase Alpha. These steps can be adapted for Moonbeam and Moonriver. The guide assumes that there is one already taking place. If there is an open referendum that you want to vote on, you can adapt these instructions to learn how to vote on it.
+This section goes over the process of voting on a public referendum in OpenGov (Governance v2) on Moonbase Alpha. These steps can be adapted for Moonbeam and Moonriver. The guide assumes that there is one already taking place. If there is an open referendum that you want to vote on, you can adapt these instructions to learn how to vote on it.
 
-To vote on a proposal in the network, you need to use the Polkadot.js Apps interface. To do so, you need to import an Ethereum-style account first (H160 address), which you can do by following the [Creating or Importing an H160 Account](/tokens/connect/polkadotjs/#creating-or-importing-an-h160-account){target=_blank} guide. For this example, three accounts were imported and named with super original names: Alice, Bob, and Charlie.
+To vote on a proposal on the network, you need to use the Polkadot.js Apps interface. To do so, you need to import an Ethereum-style account first (H160 address), which you can do by following the [Creating or Importing an H160 Account](/tokens/connect/polkadotjs/#creating-or-importing-an-h160-account){target=_blank} guide. For this example, three accounts were imported and named with super original names: Alice, Bob, and Charlie.
 
 ![Accounts in Polkadot.js](/images/tokens/governance/proposals/proposals-3.png)
 
@@ -84,7 +84,7 @@ To get started, you'll need to navigate to [Moonbase Alpha's Polkadot.js Apps in
 
 ### How to Support a Proposal by Contributing to the Decision Deposit {: #submit-decision-deposit }
 
-In order for a referendum to move out of the Lead-in Period into the Decide Period, the Decision Deposit must be submitted. This deposit can be submitted by the author of the proposal or any other token-holder. The deposit varies depending upon the Track of the proposal.
+In order for a referendum to move out of the Lead-in Period into the Decide Period, the Decision Deposit must be submitted. This deposit can be submitted by the author of the proposal or any other token holder. The deposit varies depending on the Track of the proposal.
 
 For example, a referendum that is in the General Admin Track has a Decision Deposit of {{ networks.moonbase.governance.tracks.general_admin.decision_deposit }} on Moonbase Alpha.
 
@@ -94,7 +94,7 @@ From the [list of referenda on Polkadot.js Apps](https://polkadot.js.org/apps/?r
 
 Then take the following steps to submit the deposit from a specific account:
 
-1. Select the **deposit from account**. This account does not need to be the author of the proposal, it can be from any token holder. However, if the proposal is deemed malicious, the Decision Deposit will be burned. So, before placing the deposit it is advised to do your due dilligence to ensure the proposal is not malicious
+1. Select the **deposit from account**. This account does not need to be the author of the proposal; it can be from any token holder. However, if the proposal is deemed malicious, the Decision Deposit will be burned. So, before placing the deposit, it is advised to do your due diligence to ensure the proposal is not malicious
 2. The **referendum id** and **decision deposit** fields will automatically be populated for you based on the referendum and Track it belongs to
 3. Click **Place deposit** and sign the transaction
 
@@ -102,53 +102,53 @@ Then take the following steps to submit the deposit from a specific account:
 
 Once the deposit has been placed, Polkadot.js Apps will update and display the account that paid the Decision Deposit along with the amount of the deposit. Now this referendum is one step closer to meeting the criteria of the Lead-in Period.
 
-If the Prepare Period has passed and there is enough space for a referndum in the General Admin Track, this proposal will move on to the Decide Period.
+If the Prepare Period has passed and there is enough space for a referendum in the General Admin Track, this proposal will move on to the Decide Period.
 
 ### How to Vote {: #how-to-vote }
 
 As you may have noticed, voting is not required in the Lead-in Period. However, it is essential in the Decide Period. The steps in this section will apply to referenda in both the Lead-in Period and the Decide Period.
 
-To vote and lock tokens either in favor of or opposition of a referendum, you can get started by clicking on the **Vote** button next to the referendum you want to vote on.
+To vote and lock tokens either in favor of or against a referendum, you can get started by clicking on the **Vote** button next to the referendum you want to vote on.
 
 ![To vote on a referendum, click on the "Vote" button on Polkadot.js Apps.](/images/tokens/governance/voting/vote-4.png)
 
 Then you can take the following steps to fill in the details of the vote:
 
 1. Select the **vote with account**
-2. Choose how you would like to vote on the referendum. You can choose **Aye** in favor of the referendum, **Nay** in opposition of it, or **Split** if you want to specify an "Aye" vote value and "Nay" vote value
-3. Enter in the vote value
+2. Choose how you would like to vote on the referendum. You can choose **Aye** in favor of the referendum, **Nay** in opposition to it, or **Split** if you want to specify an "Aye" vote value and a "Nay" vote value
+3. Enter the vote value
 4. Set the vote conviction, which determines the weight of your vote (`vote_weight = tokens * conviction_multiplier`). Please refer to the [Conviction multiplier](/learn/features/governance/#conviction-multiplier){target=_blank} docs for more information
 5. Click **Vote** and sign the transaction
 
 ![To submit a vote on a referendum, fill out the details of the vote and click on the "Vote" button on Polkadot.js Apps.](/images/tokens/governance/voting/vote-5.png)
 
 !!! note
-    The lockup periods shown in the previous image are not to be taken as reference as they are subject to change.
+    The lockup periods shown in the previous image are not to be taken as references as they are subject to change.
 
-To see how your vote and all of the other votes for a referendum impacted the Approval and Support curves, you can click on the arrow next to the **Vote** button. You'll notice there are two charts, one for each curve. If you hover over the charts, you can see the minimum Approval or Support required at a specific block along with the current Approval or Support.
+To see how your vote and all of the other votes for a referendum impacted the Approval and Support curves, you can click on the arrow next to the **Vote** button. You'll notice there are two charts, one for each curve. If you hover over the charts, you can see the minimum Approval or Support required for a specific block along with the current Approval or Support.
 
 ![View the Approval and Support curves for a referendum on Polkadot.js Apps.](/images/tokens/governance/voting/vote-6.png)
 
 A proposal in the General Admin Track on Moonbase Alpha would have the following characteristics:
 
- - The Approval curve starts at {{ networks.moonbase.governance.tracks.general_admin.min_approval.percent0 }}% on {{ networks.moonbase.governance.tracks.general_admin.min_approval.time0 }}, goes to {{ networks.moonbase.governance.tracks.general_admin.min_approval.percent1 }}% on {{ networks.moonbase.governance.tracks.general_admin.min_approval.time1 }}
- - The Support curve starts at {{ networks.moonbase.governance.tracks.general_admin.min_support.percent0 }}% on {{ networks.moonbase.governance.tracks.general_admin.min_support.time0 }}, goes to {{ networks.moonbase.governance.tracks.general_admin.min_support.percent1 }}% on {{ networks.moonbase.governance.tracks.general_admin.min_support.time1 }}
+ - The Approval curve starts at {{ networks.moonbase.governance.tracks.general_admin.min_approval.percent0 }}% on {{ networks.moonbase.governance.tracks.general_admin.min_approval.time0 }} and goes to {{ networks.moonbase.governance.tracks.general_admin.min_approval.percent1 }}% on {{ networks.moonbase.governance.tracks.general_admin.min_approval.time1 }}
+ - The Support curve starts at {{ networks.moonbase.governance.tracks.general_admin.min_support.percent0 }}% on {{ networks.moonbase.governance.tracks.general_admin.min_support.time0 }} and goes to {{ networks.moonbase.governance.tracks.general_admin.min_support.percent1 }}% on {{ networks.moonbase.governance.tracks.general_admin.min_support.time1 }}
  - A referendum starts the Decide Period with 0% "Aye" votes (nobody voted in the Lead-in Period)
- - Token holders begin to vote and the Approval increases to a value above {{ networks.moonbase.governance.tracks.general_admin.min_approval.percent1 }}% by {{ networks.moonbase.governance.tracks.general_admin.min_approval.time1 }}
+ - Token holders begin to vote, and the Approval increases to a value above {{ networks.moonbase.governance.tracks.general_admin.min_approval.percent1 }}% by {{ networks.moonbase.governance.tracks.general_admin.min_approval.time1 }}
  - If the Approval and Support thresholds are met for the duration of the Confirm Period ({{ networks.moonbase.governance.tracks.general_admin.confirm_period.blocks }} blocks, approximately {{ networks.moonbase.governance.tracks.general_admin.confirm_period.time }}), the referendum is approved
  - If the Approval and Support thresholds are not met during the Decision Period, the proposal is rejected. Note that the thresholds need to be met for the duration of the Confirm Period. Consequently, if they are met but the Decision Period expires before the completion of the Confirm Period, the proposal is rejected
 
-In the following image, you'll notice enough Approval and Support have been received and so the Confirm Period is underway. if the referendum maintains the Approval and Support levels, at block 124,962 the Confirm Period will end and then the Enactment Period will begin. You can hover over the charts to find out more information on each of these periods. Assuming this referendum maintains the levels of Approval and Support it has received, the Enactment Period will end at block 132,262 and the proposal action will be dispatched.
+In the following image, you'll notice enough Approval and Support have been received, so the Confirm Period is underway. If the referendum maintains the Approval and Support levels, at block 124,962, the Confirm Period will end, and then the Enactment Period will begin. You can hover over the charts to find out more information on each of these periods. Assuming this referendum maintains the levels of Approval and Support it has received, the Enactment Period will end at block 132,262, and the proposal action will be dispatched.
 
 ![View the Approval and Support curves for a referendum on Polkadot.js Apps.](/images/tokens/governance/voting/vote-7.png)
 
-If the referendum doesn't continuously receive enough Approval and Support during the Confirm Period, it still has a chance to pass as long as the Approval and Support requirements are met again and continously for the duration of the Confirm Period. If a referendum enters the Confirm Period but the Decide Period is set to end before the Confirm Period is over, the Decide Period will actually be extended until the end of the Confirm Period. If the Decide Period ends and the referendum still hasn't received enough Approval and Support, the referendum will be rejected and the Decision Deposit is able to be refunded.
+If the referendum doesn't continuously receive enough Approval and Support during the Confirm Period, it still has a chance to pass as long as the Approval and Support requirements are met again and continuously for the duration of the Confirm Period. If a referendum enters the Confirm Period but the Decide Period is set to end before the Confirm Period is over, the Decide Period will actually be extended until the end of the Confirm Period. If the Decide Period ends and the referendum still hasn't received enough Approval and Support, the referendum will be rejected, and the Decision Deposit can be refunded.
 
-The Enactment Period is defined by the author of the proposal at the time it was initially submitted, but it needs to be at least the minimum Enacment Period.
+The Enactment Period is defined by the author of the proposal at the time it was initially submitted, but it needs to be at least the minimum Enactment Period.
 
 ### Delegate Voting {: #delegate-voting }
 
-Token holders have the option to delegate their vote to another account whose opinion they trust. The account being delegated does not need to make any particular action. When they vote, the vote weight (that is, tokens times the Conviction multiplier chose by the delegator) is added to its vote.
+Token holders have the option to delegate their vote to another account whose opinion they trust. The account being delegated does not need to take any particular action. When they vote, the vote weight (that is, tokens times the Conviction multiplier chosen by the delegator) is added to their vote.
 
 With the introduction of OpenGov (Governance v2), token holders can even delegate their vote on a Track-by-Track basis and specify different delegates for each Track, which is referred to as Multirole Delegation.
 
@@ -174,9 +174,9 @@ You can continue the above process for each Track and delegate a different accou
 
 To undelegate a delegation, you'll need to head to the **Developer** tab and click on **Extrinsics**. From there, you can take the following steps:
 
-1. Select the account you have delegate from
+1. Select the account you have delegated from
 2. Choose the **convictionVoting** pallet and the **undelegate** extrinsic
-3. Enter the **class** of the Origin. For the General Admin Track, it is `2`. For the complete list of Track IDs, you can refer to the [OpenGov section of the governance overview page](/learn/features/governance/#general-parameters-by-track){target=_blank}
+3. Enter the **class** of the Origin. For the General Admin Track, it is `2`. For a complete list of Track IDs, refer to the [OpenGov section of the governance overview page](/learn/features/governance/#general-parameters-by-track){target=_blank}
 4. Click **Submit transaction** and sign the transaction
 
 ![Undelegate a vote on Polkadot.js Apps.](/images/tokens/governance/voting/vote-10.png)
@@ -187,16 +187,16 @@ If a referendum has been approved or rejected, the Decision Deposit will be elig
 
 ![Get started refunding a Decision Deposit from a passed referendum on Polkadot.js Apps.](/images/tokens/governance/voting/vote-11.png)
 
-Then to submit the refund transaction, you can:
+Then, to submit the refund transaction, you can:
 
-1. Choose the account you want to trigger the refund. This does not need to be the account that initially placed the deposit
+1. Choose the account for which you want to trigger the refund. This does not need to be the account that initially placed the deposit
 2. Click **Refund deposit** and sign the transaction
 
 ![Refund the Decision Deposit on Polkadot.js Apps.](/images/tokens/governance/voting/vote-12.png)
 
 ### Unlocking Locked Tokens {: #unlocking-locked-tokens }
 
-When token holders vote, the tokens used are locked and cannot be transferred. You can verify if you have any locked tokens in the **Accounts** tab by expanding the address's account details. There, you will see different types of balances. If you have any tokens locked in referenda, you'll see **referenda** listed in your balance details and can hover over it to find out details about which referendum your tokens are locked for. Different lock statuses include:
+When token holders vote, the tokens used are locked and cannot be transferred. You can verify if you have any locked tokens in the **Accounts** tab by expanding the address's account details. There, you will see different types of balances. If you have any tokens locked in referenda, you'll see **referenda** listed in your balance details, and you can hover over it to find out details about which referendum your tokens are locked for. Different lock statuses include:
 
  - Locked because of an ongoing referendum, meaning that you've used your tokens and have to wait until the referendum finishes, even if you've voted with a no-lock Conviction factor
  - Locked because of the Conviction multiplier selected, displaying the number of blocks and time left
@@ -204,12 +204,12 @@ When token holders vote, the tokens used are locked and cannot be transferred. Y
 
 ![View locked balances on the account page of Polkadot.js Apps.](/images/tokens/governance/voting/vote-13.png)
 
-Once the lock is expired, you can request your tokens back. To do so, navigate to the **Extrinsics** menu under the **Developers** tab. Here, two different extrinsics need to be sent. First, you need to provide the following information:
+Once the lock has expired, you can request your tokens back. To do so, navigate to the **Extrinsics** menu under the **Developers** tab. Here, two different extrinsics need to be sent. First, you need to provide the following information:
 
  1. Select the account from which you want to recover your tokens
- 2. Choose the pallet you want to interact with. In this case, it is the `convictionVoting` pallet and the extrinsic to use for the transaction. This will determine the fields that you need to fill in the following steps. In this case, it is `removeVote` extrinsic. This step is necessary to unlock the tokens. This extrinsic can be used as well to remove your vote from a referendum
- 4. Optionally, you can specify the Track ID to remove votes for. To do so, simply toggle the **include option** slider and enter in the Track ID in the **class u16** field
- 5. Enter the referendum index. This is the number that appeared on the left-hand side in the **Referenda** tab
+ 2. Choose the pallet you want to interact with. In this case, it is the `convictionVoting` pallet and the extrinsic to use for the transaction. This will determine the fields that you need to fill in the following steps. In this case, it is `removeVote` extrinsic. This step is necessary to unlock the tokens. This extrinsic can also be used to remove your vote from a referendum
+ 4. Optionally, you can specify the Track ID to remove votes for. To do so, simply toggle the **include option** slider and enter the Track ID in the **class u16** field
+ 5. Enter the referendum index. This is the number that appeared on the left-hand side of the **Referenda** tab
  6. Click the **Submit Transaction** button and sign the transaction
 
 ![Submit an extrinsic to remove your vote on a referendum in Polkadot.js Apps.](/images/tokens/governance/voting/vote-14.png)
@@ -218,7 +218,7 @@ For the next extrinsic, you need to provide the following information:
 
  1. Select the account from which you want to recover your tokens
  2. Choose the pallet you want to interact with. In this case, it is the `convictionVoting` pallet
- 3. Choose the extrinsic method to use for the transaction. This will determine the fields that need to fill in the following steps. In this case, it is `unlock` extrinsic
+ 3. Choose the extrinsic method to use for the transaction. This will determine the fields that need to be filled out in the following steps. In this case, it is the `unlock` extrinsic
  4. Enter the Track ID to remove the voting lock for
  5. Enter the target account that will receive the unlocked tokens. In this case, the tokens will be returned to Alice
  6. Click the **Submit Transaction** button and sign the transaction

--- a/tokens/governance/voting.md
+++ b/tokens/governance/voting.md
@@ -7,16 +7,16 @@ description: Follow this guide to learn how to vote and lock your tokens to supp
 
 ## Introduction {: #introduction }
 
-Referenda are simple, inclusive, and stake-based voting schemes. Each referendum has a proposal associated with it that suggests an action to take place. In OpenGov, each referendum will have a specified Origin class that the proposal will be executed with and each Origin has its own Track that proposals will process through. Although referenda are completed by a common process, the requirements for approval are Track-specific.
+Referenda are simple, inclusive, and stake-based voting schemes. Each referendum has a proposal associated with it that suggests an action to take place. In OpenGov, each referendum will have a specified Origin class that the proposal will be executed with, and each Origin has its own Track that proposals will process through. Although referenda are completed by a common process, the requirements for approval are Track-specific.
 
-Token holders can vote on referenda using their own tokens. Two factors defined the weight a vote has: the number of tokens locked and lock duration (called Conviction). This is to ensure that there is an economic buy-in to the result to prevent vote-selling. Consequently, the longer you are willing to lock your tokens, the stronger your vote will be weighted. You also have the option of not locking tokens at all, but vote weight is drastically reduced.
+Token holders can vote on referenda using their own tokens, including those that are locked in staking. The weight of a vote is defined by two factors: the number of tokens locked and the lock duration (called Conviction). This is to ensure that there is an economic buy-in to prevent vote-selling. Consequently, the longer you are willing to lock your tokens, the stronger your vote will be weighted. You also have the option of not locking tokens at all, but the vote weight is drastically reduced.
 
 In Moonbeam, users will be able to create and vote on proposals using their H160 address and private key, that is, their regular Ethereum account!
 
 This guide will outline the process, with step-by-step instructions, of how to vote on referenda in Governance v2: OpenGov. This guide will show you how to vote on Moonbase Alpha, but it can be easily adapted for Moonbeam and Moonriver.
 
 !!! note
-    This page goes through the mechanics on how to vote at a more techincal level. Token holders can leverage platforms such as [Polkassembly](https://moonbeam.network/tutorial/participate-in-moonbeam-governance-with-polkassembly/){target=_blank} to vote using a more friendly user interface.
+    This page goes through the mechanics of how to vote at a more technical level. Token holders can leverage platforms such as [Polkassembly](https://moonbeam.network/tutorial/participate-in-moonbeam-governance-with-polkassembly/){target=_blank} to vote using a more friendly user interface.
 
 ## Definitions {: #definitions }
 


### PR DESCRIPTION
### Description

This PR adds or updates the following:
- adds more examples on the XCM SDK in regards to getting supported asset information and where the assets can be sent from/to
- adds a section on common errors when sending a transaction with Web3.js
- updates the voting on governance page to explicitly state that tokens locked in staking can be used to vote on referenda and cleans up the intro to this page
- fix the `--sync` flag so it is wrapped in back ticks

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
