### PR TITLE
Update usage of the balances pallet

### DIFF
--- a/.snippets/code/builders/build/substrate-api/polkadot-js-api/basic-transactions.js
+++ b/.snippets/code/builders/build/substrate-api/polkadot-js-api/basic-transactions.js
@@ -14,7 +14,7 @@ const main = async () => {
   const bob = 'INSERT_BOBS_ADDRESS';
 
   // Form the transaction
-  const tx = await api.tx.balances.transferKeepAlive(bob, BigInt(12345));
+  const tx = await api.tx.balances.transferAllowDeath(bob, BigInt(12345));
 
   // Retrieve the encoded calldata of the transaction
   const encodedCalldata = tx.method.toHex();

--- a/.snippets/code/builders/build/substrate-api/polkadot-js-api/basic-transactions.js
+++ b/.snippets/code/builders/build/substrate-api/polkadot-js-api/basic-transactions.js
@@ -14,7 +14,7 @@ const main = async () => {
   const bob = 'INSERT_BOBS_ADDRESS';
 
   // Form the transaction
-  const tx = await api.tx.balances.transfer(bob, BigInt(12345));
+  const tx = await api.tx.balances.transferKeepAlive(bob, BigInt(12345));
 
   // Retrieve the encoded calldata of the transaction
   const encodedCalldata = tx.method.toHex();

--- a/.snippets/code/builders/build/substrate-api/polkadot-js-api/batch-transactions.js
+++ b/.snippets/code/builders/build/substrate-api/polkadot-js-api/batch-transactions.js
@@ -15,8 +15,8 @@ const main = async () => {
   // Construct a list of transactions to batch
   const collator = 'INSERT_COLLATORS_ADDRESS';
   const txs = [
-    api.tx.balances.transfer('INSERT_BOBS_ADDRESS', BigInt(12345)),
-    api.tx.balances.transfer('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
+    api.tx.balances.transferKeepAlive('INSERT_BOBS_ADDRESS', BigInt(12345)),
+    api.tx.balances.transferKeepAlive('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
     api.tx.parachainStaking.scheduleDelegatorBondLess(collator, BigInt(12345)),
   ];
 

--- a/.snippets/code/builders/build/substrate-api/polkadot-js-api/batch-transactions.js
+++ b/.snippets/code/builders/build/substrate-api/polkadot-js-api/batch-transactions.js
@@ -15,8 +15,8 @@ const main = async () => {
   // Construct a list of transactions to batch
   const collator = 'INSERT_COLLATORS_ADDRESS';
   const txs = [
-    api.tx.balances.transferKeepAlive('INSERT_BOBS_ADDRESS', BigInt(12345)),
-    api.tx.balances.transferKeepAlive('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
+    api.tx.balances.transferAllowDeath('INSERT_BOBS_ADDRESS', BigInt(12345)),
+    api.tx.balances.transferAllowDeath('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
     api.tx.parachainStaking.scheduleDelegatorBondLess(collator, BigInt(12345)),
   ];
 

--- a/.snippets/code/builders/build/substrate-api/polkadot-js-api/payment-info.js
+++ b/.snippets/code/builders/build/substrate-api/polkadot-js-api/payment-info.js
@@ -6,7 +6,7 @@ const main = async () => {
   const api = await ApiPromise.create({ provider: wsProvider });
 
   // Transaction to get weight information
-  const tx = api.tx.balances.transfer('INSERT_BOBS_ADDRESS', BigInt(12345));
+  const tx = api.tx.balances.transferKeepAlive('INSERT_BOBS_ADDRESS', BigInt(12345));
 
   // Get weight info
   const { partialFee, weight } = await tx.paymentInfo('INSERT_SENDERS_ADDRESS');

--- a/.snippets/code/builders/build/substrate-api/polkadot-js-api/payment-info.js
+++ b/.snippets/code/builders/build/substrate-api/polkadot-js-api/payment-info.js
@@ -6,7 +6,7 @@ const main = async () => {
   const api = await ApiPromise.create({ provider: wsProvider });
 
   // Transaction to get weight information
-  const tx = api.tx.balances.transferKeepAlive('INSERT_BOBS_ADDRESS', BigInt(12345));
+  const tx = api.tx.balances.transferAllowDeath('INSERT_BOBS_ADDRESS', BigInt(12345));
 
   // Get weight info
   const { partialFee, weight } = await tx.paymentInfo('INSERT_SENDERS_ADDRESS');

--- a/.snippets/code/builders/get-started/eth-compare/transfers-api/sidecar-transfer.js
+++ b/.snippets/code/builders/get-started/eth-compare/transfers-api/sidecar-transfer.js
@@ -52,7 +52,7 @@ async function main() {
       if (
         extrinsic.method.pallet === 'balances' &&
         (extrinsic.method.method === 'transferKeepAlive' ||
-          extrinsic.method.method === 'transfer')
+          extrinsic.method.method === 'transferAllowDeath')
       ) {
         // Iterate through the events to get transaction details
         extrinsic.events.forEach((event) => {

--- a/builders/build/substrate-api/polkadot-js-api.md
+++ b/builders/build/substrate-api/polkadot-js-api.md
@@ -295,7 +295,7 @@ const alice = keyring.addFromUri('INSERT_ALICES_PRIVATE_KEY');
 const bob = 'INSERT_BOBS_ADDRESS';
 
 // Form the transaction
-const tx = await api.tx.balances.transferKeepAlive(bob, 12345n);
+const tx = await api.tx.balances.transferAllowDeath(bob, 12345n);
 
 // Retrieve the encoded calldata of the transaction
 const encodedCalldata = tx.method.toHex();
@@ -327,7 +327,7 @@ For example, assuming you've [initialized the API](#creating-an-API-provider-ins
 
 ```javascript
 // Transaction to get weight information
-const tx = api.tx.balances.transferKeepAlive('INSERT_BOBS_ADDRESS', BigInt(12345));
+const tx = api.tx.balances.transferAllowDeath('INSERT_BOBS_ADDRESS', BigInt(12345));
 
 // Get weight info
 const { partialFee, weight } = await tx.paymentInfo('INSERT_SENDERS_ADDRESS');
@@ -360,8 +360,8 @@ For example, assuming you've [initialized the API](#creating-an-API-provider-ins
 // Construct a list of transactions to batch
 const collator = 'INSERT_COLLATORS_ADDRESS';
 const txs = [
-  api.tx.balances.transferKeepAlive('INSERT_BOBS_ADDRESS', BigInt(12345)),
-  api.tx.balances.transferKeepAlive('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
+  api.tx.balances.transferAllowDeath('INSERT_BOBS_ADDRESS', BigInt(12345)),
+  api.tx.balances.transferAllowDeath('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
   api.tx.parachainStaking.scheduleDelegatorBondLess(collator, BigInt(12345)),
 ];
 

--- a/builders/build/substrate-api/polkadot-js-api.md
+++ b/builders/build/substrate-api/polkadot-js-api.md
@@ -315,6 +315,9 @@ console.log(`Submitted with hash ${txHash}`);
     --8<-- 'code/builders/build/substrate-api/polkadot-js-api/basic-transactions.js'
     ```
 
+!!! note
+    Prior to client v0.35.0, the extrinsic used to perform a simple balance transfer was the `balances.transfer` extrinsic. It has since been deprecated and replaced with the `balances.transferAllowDeath` extrinsic.
+
 Note that the `signAndSend` function can also accept optional parameters, such as the `nonce`. For example, `signAndSend(alice, { nonce: aliceNonce })`. You can use the [sample code from the State Queries](/builders/build/substrate-api/polkadot-js-api/#state-queries){target=_blank} section to retrieve the correct nonce, including transactions in the mempool.
 
 ### Fee Information {: #fees }

--- a/builders/build/substrate-api/polkadot-js-api.md
+++ b/builders/build/substrate-api/polkadot-js-api.md
@@ -295,8 +295,7 @@ const alice = keyring.addFromUri('INSERT_ALICES_PRIVATE_KEY');
 const bob = 'INSERT_BOBS_ADDRESS';
 
 // Form the transaction
-const tx = await api.tx.balances
-  .transfer(bob, 12345n);
+const tx = await api.tx.balances.transferKeepAlive(bob, 12345n);
 
 // Retrieve the encoded calldata of the transaction
 const encodedCalldata = tx.method.toHex();
@@ -328,7 +327,7 @@ For example, assuming you've [initialized the API](#creating-an-API-provider-ins
 
 ```javascript
 // Transaction to get weight information
-const tx = api.tx.balances.transfer('INSERT_BOBS_ADDRESS', BigInt(12345));
+const tx = api.tx.balances.transferKeepAlive('INSERT_BOBS_ADDRESS', BigInt(12345));
 
 // Get weight info
 const { partialFee, weight } = await tx.paymentInfo('INSERT_SENDERS_ADDRESS');
@@ -361,8 +360,8 @@ For example, assuming you've [initialized the API](#creating-an-API-provider-ins
 // Construct a list of transactions to batch
 const collator = 'INSERT_COLLATORS_ADDRESS';
 const txs = [
-  api.tx.balances.transfer('INSERT_BOBS_ADDRESS', BigInt(12345)),
-  api.tx.balances.transfer('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
+  api.tx.balances.transferKeepAlive('INSERT_BOBS_ADDRESS', BigInt(12345)),
+  api.tx.balances.transferKeepAlive('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
   api.tx.parachainStaking.scheduleDelegatorBondLess(collator, BigInt(12345)),
 ];
 

--- a/builders/get-started/eth-compare/transfers-api.md
+++ b/builders/get-started/eth-compare/transfers-api.md
@@ -32,7 +32,7 @@ Before going over the different scenarios, there are two different elements asso
 
 The different transfer scenarios are:
 
- - **Substrate transfer** — it will create an extrinsic, either `balances.transfer` or `balances.transferKeepAlive`. It will trigger **one** `balances.Transfer` event
+ - **Substrate transfer** — it will create an extrinsic, either `balances.transferAllowDeath` or `balances.transferKeepAlive`. It will trigger **one** `balances.Transfer` event
  - **Substrate feature** — some native Substrate features can create extrinsic that would send tokens to an address. For example, [Treasury](/learn/features/treasury/){target=_blank} can create an extrinsic such as `treasury.proposeSend`, which will trigger **one or multiple** `balances.Transfer` events
  - **Ethereum transfer** — it will create an `ethereum.transact` extrinsic with an empty input. It will trigger **one** `balances.Transfer` event
  - **Ethereum transfers via smart contracts** — it will create an `ethereum.transact` extrinsic with some data as input. It will trigger **one or multiple** `balances.Transfer` events


### PR DESCRIPTION
### Description

The `transfer` extrinsic has been deprecated with v1.3.0 of the polkadot-sdk, which has been introduced to moonbeam in [client v0.35.0](https://github.com/moonbeam-foundation/moonbeam/releases)

### Checklist

- [x] I have added a label to this PR 🏷️

### Corresponding PRs

Goes with CN PR: https://github.com/moonbeam-foundation/moonbeam-docs-cn/pull/385
