### PR TITLE
bump to client v0.35.0

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
-    build_tag: v0.34.1
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.34.1-2602-latest
+    build_tag: v0.35.0
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.35.0-2700-latest
     rpc_url: http://127.0.0.1:9944
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -16,9 +16,9 @@ networks:
     chain_spec: alphanet
     block_explorer: https://moonbase.moonscan.io/
     spec_version: runtime-2601
-    parachain_release_tag: v0.34.1 # must be in this exact format for links to work
-    parachain_sha256sum: 490d170e2af41f27d809c37d595d04d224e3abf6bda27de5dfcd10768b59428e
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.34.1-2602-latest
+    parachain_release_tag: v0.35.0 # must be in this exact format for links to work
+    parachain_sha256sum: 1b63dd42fa2692956a1c8f1e8d0ee46a3b5f00db9e11146e3b2b665c157661da
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.35.0-2700-latest
     gas_block: 15,000,000
     gas_block_numbers_only: 15000000
     gas_tx: 12,995,000
@@ -392,9 +392,9 @@ networks:
     chain_id: 1285
     hex_chain_id: '0x505'
     node_directory: /var/lib/moonriver-data
-    parachain_release_tag: v0.34.1
-    parachain_sha256sum: 490d170e2af41f27d809c37d595d04d224e3abf6bda27de5dfcd10768b59428e
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.34.1-2602-latest
+    parachain_release_tag: v0.35.0
+    parachain_sha256sum: 1b63dd42fa2692956a1c8f1e8d0ee46a3b5f00db9e11146e3b2b665c157661da
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.35.0-2700-latest
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     spec_version: runtime-2601
@@ -735,9 +735,9 @@ networks:
     chain_id: 1284
     hex_chain_id: '0x504'
     node_directory: /var/lib/moonbeam-data
-    parachain_release_tag: v0.34.1
-    parachain_sha256sum: 490d170e2af41f27d809c37d595d04d224e3abf6bda27de5dfcd10768b59428e
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.34.1-2602-latest
+    parachain_release_tag: v0.35.0
+    parachain_sha256sum: 1b63dd42fa2692956a1c8f1e8d0ee46a3b5f00db9e11146e3b2b665c157661da
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.35.0-2700-latest
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     spec_version: runtime-2601


### PR DESCRIPTION
### Description

This PR bumps the client version to v0.35.0! No additional PRs are needed for the CN repo! 🎉 

### Checklist

- [x] I have added a label to this PR 🏷️

