### PR TITLE
update subsquid archive urls

### DIFF
--- a/builders/integrations/indexers/subsquid.md
+++ b/builders/integrations/indexers/subsquid.md
@@ -49,19 +49,19 @@ To get started indexing Substrate data on Moonbeam, you'll need to create a Subs
     === "Moonbeam"
 
         ```json
-        "specVersions": "https://v2.archive.subsquid.io/network/moonbeam-mainnet",
+        "specVersions": "https://v2.archive.subsquid.io/metadata/moonbeam",
         ```
 
     === "Moonriver"
 
         ```json
-        "specVersions": "https://v2.archive.subsquid.io/network/moonriver-mainnet",
+        "specVersions": "https://v2.archive.subsquid.io/metadata/moonriver",
         ```
 
     === "Moonbase Alpha"
 
         ```json
-        "specVersions": "https://v2.archive.subsquid.io/network/moonbase-testnet",
+        "specVersions": "https://v2.archive.subsquid.io/metadata/moonbase",
         ```
 
 4. Modify the `src/processor.ts` file, which is where Squids instantiate the processor, configure it, and attach handler functions. The processor fetches historical on-chain data from an [Archive](https://docs.subsquid.io/archives/overview/){target=_blank}, which is a specialized data lake. You'll need to configure your processor to pull data from the Archive that corresponds to the [network](https://docs.subsquid.io/substrate-indexing/supported-networks/){target=_blank} you are indexing data on:


### PR DESCRIPTION
### Description

This PR updates the archive links for moonbeam, moonriver, and moonbase alpha. You can quickly verify by attempting to open the urls in your browser; the old ones will return 404s, and the new ones will return data.

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira (Note: Updated existing ticket open for the latest Subsquid translations)

### After Translation Requirements

- [x] No additional PRs are required after the translations are done