### PR TITLE
update termynal snippets

### DIFF
--- a/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-pull.md
+++ b/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-pull.md
@@ -1,5 +1,5 @@
 <div id="termynal" data-termynal>
-  <span data-ty="input">docker pull moonbeamfoundation/moonbeam:v0.35.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.35.0</span>
   <br>
   <span data-ty>v0.35.0: Pulling from moonbeamfoundation/moonbeam
     <br> af107e978371: Pull complete

--- a/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-run.md
+++ b/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-run.md
@@ -1,5 +1,5 @@
 <div id="termynal" data-termynal>
-  <span data-ty="input">docker run --rm --name moonbeam_development --network host \
+  <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
     <br> moonbeamfoundation/moonbeam:v0.35.0 \
     <br> --dev --rpc-external
   </span>

--- a/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/run-binary.md
+++ b/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/run-binary.md
@@ -1,5 +1,5 @@
 <div id="termynal" data-termynal>
-  <span data-ty="input">./target/release/moonbeam --dev</span>
+  <span data-ty="input"><span class="file-path"></span>./target/release/moonbeam --dev</span>
   <br>
   <span data-ty>CLI parameter `--execution` has no effect anymore and will be removed in the future!
     <br> 2024-01-10 06:41:29 Moonbeam Parachain Collator


### PR DESCRIPTION
### Description

This PR updates the termynal snippets to separate the file path (`~$`) from the system name (`moonbeam@ubuntu-jammy`)

~~Goes with https://github.com/papermoonio/moonbeam-mkdocs/pull/158 and https://github.com/moonbeam-foundation/moonbeam-docs-cn/pull/396~~

Goes with: https://github.com/papermoonio/moonbeam-mkdocs/pull/159
