### PR TITLE
update xcm transactor for the overall weight changes

### DIFF
--- a/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet/interface-examples/hrmp-manage.js
+++ b/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet/interface-examples/hrmp-manage.js
@@ -12,7 +12,7 @@ const weightInfo = {
     refTime: INSERT_REF_TIME,
     proofSize: INSERT_PROOF_SIZE,
   },
-  overallWeight: { refTime: INSERT_REF_TIME, proofSize: INSERT_PROOF_SIZE },
+  overallWeight: { Unlimited: null },
 };
 
 const main = async () => {

--- a/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet/interface-examples/transact-through-signed.js
+++ b/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet/interface-examples/transact-through-signed.js
@@ -18,7 +18,7 @@ const weightInfo = {
     refTime: INSERT_REF_TIME,
     proofSize: INSERT_PROOF_SIZE,
   },
-  overallWeight: { refTime: INSERT_REF_TIME, proofSize: INSERT_PROOF_SIZE },
+  overallWeight: { Unlimited: null },
 };
 const refund = INSERT_BOOLEAN_FOR_REFUND;
 

--- a/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet/interface-examples/transact-through-sovereign.js
+++ b/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet/interface-examples/transact-through-sovereign.js
@@ -20,7 +20,7 @@ const weightInfo = {
     refTime: INSERT_REF_TIME,
     proofSize: INSERT_PROOF_SIZE,
   },
-  overallWeight: { refTime: INSERT_REF_TIME, proofSize: INSERT_PROOF_SIZE },
+  overallWeight: { Unlimited: null },
 };
 const refund = INSERT_BOOLEAN_FOR_REFUND;
 

--- a/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet/transact-signed.js
+++ b/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet/transact-signed.js
@@ -18,7 +18,7 @@ const fee = {
 const call = '0x030044236223ab4291b93eed10e4b511b37a398dee5513000064a7b3b6e00d';
 const weightInfo = {
   transactRequiredWeightAtMost: { refTime: 1000000000n, proofSize: 40000n },
-  overallWeight: { refTime: 2000000000n, proofSize: 50000n },
+  overallWeight: { Unlimited: null },
 };
 const refund = true;
 

--- a/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-precompile/XcmTransactorV3.sol
+++ b/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-precompile/XcmTransactorV3.sol
@@ -69,7 +69,8 @@ interface XcmTransactorV3 {
     /// @param transactRequiredWeightAtMost The weight we want to buy in the destination chain
     /// @param innerCall The inner call to be executed in the destination chain
     /// @param feeAmount Amount to be used as fee.
-    /// @param overallWeight Overall weight to be used for the xcm message.
+    /// @param overallWeight Overall weight to be used for the xcm message. If uint64:MAX is passed 
+    /// through refTime field, Unlimited variant will be used. 
     /// @param refund Indicates if RefundSurplus instruction will be appended
     function transactThroughDerivativeMultilocation(
         uint8 transactor,
@@ -92,7 +93,8 @@ interface XcmTransactorV3 {
     /// @param transactRequiredWeightAtMost The weight we want to buy in the destination chain
     /// @param innerCall The inner call to be executed in the destination chain
     /// @param feeAmount Amount to be used as fee.
-    /// @param overallWeight Overall weight to be used for the xcm message.
+    /// @param overallWeight Overall weight to be used for the xcm message. If uint64:MAX is passed 
+    /// through refTime field, Unlimited variant will be used. 
     /// @param refund Indicates if RefundSurplus instruction will be appended
     function transactThroughDerivative(
         uint8 transactor,
@@ -116,7 +118,8 @@ interface XcmTransactorV3 {
     /// @param transactRequiredWeightAtMost The weight we want to buy in the destination chain for the call to be made
     /// @param call The call to be executed in the destination chain
     /// @param feeAmount Amount to be used as fee.
-    /// @param overallWeight Overall weight to be used for the xcm message.
+    /// @param overallWeight Overall weight to be used for the xcm message. If uint64:MAX is passed 
+    /// through refTime field, Unlimited variant will be used. 
     /// @param refund Indicates if RefundSurplus instruction will be appended
     function transactThroughSignedMultilocation(
         Multilocation memory dest,
@@ -139,7 +142,8 @@ interface XcmTransactorV3 {
     /// @param transactRequiredWeightAtMost The weight we want to buy in the destination chain for the call to be made
     /// @param call The call to be executed in the destination chain
     /// @param feeAmount Amount to be used as fee.
-    /// @param overallWeight Overall weight to be used for the xcm message.
+    /// @param overallWeight Overall weight to be used for the xcm message. If uint64:MAX is passed 
+    /// through refTime field, Unlimited variant will be used. 
     /// @param refund Indicates if RefundSurplus instruction will be appended
     function transactThroughSigned(
         Multilocation memory dest,

--- a/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet.md
+++ b/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet.md
@@ -43,7 +43,11 @@ The XCM Transactor Pallet provides the following extrinsics (functions):
             - `transactRequiredWeightAtMost` — the weight required to perform the execution of the `Transact` call.  The `transactRequiredWeightAtMost` structure contains the following:
                 - `refTime` - the amount of computational time that can be used for execution
                 - `proofSize` - the amount of storage in bytes that can be used
-            - `overallWeight` — (optional) the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` structure also contains `refTime` and `proofSize`
+            - `overallWeight` — (optional) the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` can be defined as either:
+                - `Unlimited` - allows an unlimited amount of weight that can be purchased
+                - `Limited` - limits the amount of weight that can be purchased by defining the following:
+                    - `refTime` - the amount of computational time that can be used for execution
+                    - `proofSize` - the amount of storage in bytes that can be used
     
     === "Polkadot.js API Example"
 
@@ -132,7 +136,11 @@ The XCM Transactor Pallet provides the following extrinsics (functions):
             - `transactRequiredWeightAtMost` — the weight required to perform the execution of the `Transact` call.  The `transactRequiredWeightAtMost` structure contains the following:
                 - `refTime` - the amount of computational time that can be used for execution
                 - `proofSize` - the amount of storage in bytes that can be used
-            - `overallWeight` — (optional) the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` structure also contains `refTime` and `proofSize`
+            - `overallWeight` — (optional) the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` can be defined as either:
+                - `Unlimited` - allows an unlimited amount of weight that can be purchased
+                - `Limited` - limits the amount of weight that can be purchased by defining the following:
+                    - `refTime` - the amount of computational time that can be used for execution
+                    - `proofSize` - the amount of storage in bytes that can be used
         - `refund` - a boolean indicating whether or not to add the `RefundSurplus` and `DepositAsset` instructions to the XCM message to refund any leftover fees 
 
     === "Polkadot.js API Example"
@@ -165,7 +173,11 @@ The XCM Transactor Pallet provides the following extrinsics (functions):
             - `transactRequiredWeightAtMost` — the weight required to perform the execution of the `Transact` call.  The `transactRequiredWeightAtMost` structure contains the following:
                 - `refTime` - the amount of computational time that can be used for execution
                 - `proofSize` - the amount of storage in bytes that can be used
-            - `overallWeight` — (optional) the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` structure also contains `refTime` and `proofSize`     
+            - `overallWeight` — (optional) the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` can be defined as either:
+                - `Unlimited` - allows an unlimited amount of weight that can be purchased
+                - `Limited` - limits the amount of weight that can be purchased by defining the following:
+                    - `refTime` - the amount of computational time that can be used for execution
+                    - `proofSize` - the amount of storage in bytes that can be used
         - `refund` - a boolean indicating whether or not to add the `RefundSurplus` and `DepositAsset` instructions to the XCM message to refund any leftover fees 
 
     === "Polkadot.js API Example"
@@ -361,12 +373,12 @@ Since you'll be interacting with the `transactThroughSigned` function of the XCM
 
 4. Set the `weightInfo`, which includes the weight specific to the inner call (`transactRequiredWeightAtMost`) and the optional overall weight of the transact plus XCM execution (`overallWeight`). For each parameter, you can follow these guidelines:
     - For `transactRequiredAtMost`, you can set `refTime` to `1000000000` weight units and `proofSize` to `40000`
-    - For `overallWeight`, the value must be the total of `transactRequiredWeightAtMost` plus the weight needed to cover the execution costs for the XCM instructions in the destination chain. If you do not provide this value, the pallet will use the element in storage (if it exists) and add it to `transactRequiredWeightAtMost`. For this example, you can set `refTime` to `2000000000` weight units and `proofSize` to `50000`
+    - For `overallWeight`, the value must be the total of `transactRequiredWeightAtMost` plus the weight needed to cover the execution costs for the XCM instructions in the destination chain. If you do not provide this value, the pallet will use the element in storage (if it exists) and add it to `transactRequiredWeightAtMost`. For this example, you can set the `overallWeight` to `Unlimited`, which removes the need to know how much weight the destination chain will require to execute the XCM
 
     ```js
     const weightInfo = {
       transactRequiredWeightAtMost: { refTime: 1000000000n, proofSize: 40000n },
-      overallWeight: { refTime: 2000000000n, proofSize: 50000n },
+      overallWeight: { Unlimited: null },
     };
     ```
 

--- a/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet.md
+++ b/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet.md
@@ -411,7 +411,7 @@ Now that you have the values for each of the parameters, you can write the scrip
 ```
 
 !!! note
-    You can view an example of the above script, which sends one token to Alice's Computed Origin account on parachain 888, on [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/extrinsics/decode/0x210603010100e10d00017576e5e612ff054915d426c546b1b21a010000c52ebca2b10000000000000000007c030044236223ab4291b93eed10e4b511b37a398dee5513000064a7b3b6e00d02286bee02710200010300943577420d030001){target=_blank} using the following encoded calldata: `0x210603010100e10d00017576e5e612ff054915d426c546b1b21a010000c52ebca2b10000000000000000007c030044236223ab4291b93eed10e4b511b37a398dee5513000064a7b3b6e00d02286bee02710200010300943577420d030001`.
+    You can view an example of the above script, which sends one token to Alice's Computed Origin account on parachain 888, on [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/extrinsics/decode/0x210603010100e10d00017576e5e612ff054915d426c546b1b21a010000c52ebca2b10000000000000000007c030044236223ab4291b93eed10e4b511b37a398dee5513000064a7b3b6e00d02286bee02710200010001){target=_blank} using the following encoded calldata: `0x210603010100e10d00017576e5e612ff054915d426c546b1b21a010000c52ebca2b10000000000000000007c030044236223ab4291b93eed10e4b511b37a398dee5513000064a7b3b6e00d02286bee02710200010001`.
 
 ### XCM Transact through Computed Origin Fees {: #transact-through-computed-origin-fees }
 

--- a/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-precompile.md
+++ b/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-precompile.md
@@ -119,7 +119,7 @@ The interface varies slightly from version to version. You can find an overview 
             - `transactRequiredWeightAtMost` - the weight to buy in the destination chain for the execution of the call defined in the `Transact` instruction
             - `call` - the call to be executed in the destination chain, as defined in the `Transact` instruction 
             - `feeAmount` - the amount to be used as a fee
-            - `overallWeight` - the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`)
+            - `overallWeight` - the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` structure also contains `refTime` and `proofSize`. If you pass in the maximum value for a uint64 for the `refTime`, you'll allow for an unlimited amount of weight to be purchased, which removes the need to know exactly how much weight the destination chain requires to execute the XCM
 
     ??? function "**transactThroughSigned**(*Multilocation* *memory* dest, *address* feeLocationAddress, *uint64* transactRequiredWeightAtMost, *bytes* *memory* call, *uint256* feeAmount, *uint64* overallWeight) — sends an XCM message with instructions to remotely execute a call in the destination chain. The remote call will be signed and executed by a new account, called the [Computed Origin](/builders/interoperability/xcm/remote-execution/computed-origins){target=_blank} account, that the destination parachain must compute. Moonbeam-based networks follow [the Computed Origins standard set by Polkadot](https://github.com/paritytech/polkadot-sdk/blob/{{ polkadot_sdk }}/polkadot/xcm/xcm-builder/src/location_conversion.rs){target=_blank}. You need to provide the address of the XC-20 asset to be used for fee payment"
 
@@ -130,7 +130,7 @@ The interface varies slightly from version to version. You can find an overview 
             - `transactRequiredWeightAtMost` - the weight to buy in the destination chain for the execution of the call defined in the `Transact` instruction
             - `call` - the call to be executed in the destination chain, as defined in the `Transact` instruction 
             - `feeAmount` - the amount to be used as a fee
-            - `overallWeight` - the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`)
+            - `overallWeight` - the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` structure also contains `refTime` and `proofSize`. If you pass in the maximum value for a uint64 for the `refTime`, you'll allow for an unlimited amount of weight to be purchased, which removes the need to know exactly how much weight the destination chain requires to execute the XCM
 
 === "V3"
 
@@ -197,7 +197,7 @@ The interface varies slightly from version to version. You can find an overview 
                 ```
             - `call` - the call to be executed in the destination chain, as defined in the `Transact` instruction 
             - `feeAmount` - the amount to be used as a fee
-            - `overallWeight` - the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` structure also contains `refTime` and `proofSize`
+            - `overallWeight` - the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` structure also contains `refTime` and `proofSize`. If you pass in the maximum value for a uint64 for the `refTime`, you'll allow for an unlimited amount of weight to be purchased, which removes the need to know exactly how much weight the destination chain requires to execute the XCM
             - `refund` -  a boolean indicating whether or not to add the `RefundSurplus` and `DepositAsset` instructions to the XCM message to refund any leftover fees 
 
     ??? function "**transactThroughSigned**(*Multilocation* *memory* dest, *address* feeLocationAddress, *Weight* transactRequiredWeightAtMost, *bytes* *memory* call, *uint256* feeAmount, *Weight* overallWeight, *bool* refund) — sends an XCM message with instructions to remotely execute a call in the destination chain. The remote call will be signed and executed by a new account, called the [Computed Origin](/builders/interoperability/xcm/remote-execution/computed-origins){target=_blank} account, that the destination parachain must compute. Moonbeam-based networks follow [the Computed Origins standard set by Polkadot](https://github.com/paritytech/polkadot-sdk/blob/{{ polkadot_sdk }}/polkadot/xcm/xcm-builder/src/location_conversion.rs){target=_blank}. You need to provide the address of the XC-20 asset to be used for fee payment"
@@ -217,7 +217,7 @@ The interface varies slightly from version to version. You can find an overview 
                 ```
             - `call` - the call to be executed in the destination chain, as defined in the `Transact` instruction 
             - `feeAmount` - the amount to be used as a fee
-            - `overallWeight` - the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` structure also contains `refTime` and `proofSize`
+            - `overallWeight` - the total weight the extrinsic can use to execute all the XCM instructions, plus the weight of the `Transact` call (`transactRequiredWeightAtMost`). The `overallWeight` structure also contains `refTime` and `proofSize`. If you pass in the maximum value for a uint64 for the `refTime`, you'll allow for an unlimited amount of weight to be purchased, which removes the need to know exactly how much weight the destination chain requires to execute the XCM
             - `refund` -  a boolean indicating whether or not to add the `RefundSurplus` and `DepositAsset` instructions to the XCM message to refund any leftover fees 
 
 ## XCM Instructions for Remote Execution {: #xcm-instructions-for-remote-execution }
@@ -314,10 +314,10 @@ For this example, you'll interact with the `transactThroughSigned` function of t
         const feeAmount = 50000000000000000n;
         ```
 
-    - `overallWeight` - the weight specific to the inner call (`transactRequiredWeightAtMost`) plus the weight needed to cover the execution costs for the XCM instructions in the destination chain: `DescendOrigin`, `WithdrawAsset`, `BuyExecution`, and `Transact`. It's important to note that each chain defines its own weight requirements. To determine the weight required for each XCM instruction on a given chain, please refer to the chain's documentation or reach out to a member of their team
+    - `overallWeight` - the weight specific to the inner call (`transactRequiredWeightAtMost`) plus the weight needed to cover the execution costs for the XCM instructions in the destination chain: `DescendOrigin`, `WithdrawAsset`, `BuyExecution`, and `Transact`. It's important to note that each chain defines its own weight requirements. To determine the weight required for each XCM instruction on a given chain, please refer to the chain's documentation or reach out to a member of their team. Alternatively, you can pass in the maximum value for a uint64 for the `refTime` (the first index of the array). This will be interpreted as using an unlimited amount of weight, which removes the need to know exactly how much weight the destination chain requires to execute the XCM
 
         ```js
-        const overallWeight = [2000000000n, 10000n];
+        const overallWeight = [18446744073709551615n, 10000n];
         ```
 
 5. Create the `transactThroughSigned` function, passing in the arguments

--- a/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-precompile.md
+++ b/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-precompile.md
@@ -343,7 +343,7 @@ For this example, you'll interact with the `transactThroughSigned` function of t
 
 ### XCM Transact through Computed Origin Fees {: #transact-through-computed-origin-fees }
 
-When [transacting through the Computed Origin account](#xcmtransactor-transact-through-signed){target=_blank}, the transaction fees are paid by the same account from which the call is dispatched, which is a Computed Origin account in the destination chain. Consequently, the Computed Origin account must hold the necessary funds to pay for the entire execution. Note that the destination token, for which fees are paid, does not need to be register as an XC-20 in the origin chain.
+When [transacting through the Computed Origin account](#xcmtransactor-transact-through-signed){target=_blank}, the transaction fees are paid by the same account from which the call is dispatched, which is a Computed Origin account in the destination chain. Consequently, the Computed Origin account must hold the necessary funds to pay for the entire execution. Note that the destination token, for which fees are paid, does not need to be registered as an XC-20 in the origin chain.
 
 To estimate the amount of token Alice's Computed Origin account will need to have to execute the remote call, you need to check the transact information specific to the destination chain. You can use the following script to get the transact information for parachain 888:
 


### PR DESCRIPTION
### Description

This PR updates the XCM Transactor pallet and precompile docs, as the `overallWeight` arg can now be set to unlimited -- as of runtime 2700

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
   - [ ] part of the XCM overhaul 

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
