### PR TITLE
Small update to AA within Particle Network tutorial

### DIFF
--- a/.snippets/code/builders/integrations/wallets/particle/configure-aa.js
+++ b/.snippets/code/builders/integrations/wallets/particle/configure-aa.js
@@ -23,9 +23,9 @@ const smartAccount = new SmartAccount(provider, {
   ...config,
   aaOptions: {
     accountContracts: {
-      SIMPLE: [
+      SIMPLE: [ // Or BICONOMY
         {
-          version: '1.0.0',
+          version: '1.0.0', // If you're using BICONOMY, set to 2.0.0
           chainIds: [Moonbeam.id],
         },
       ],
@@ -35,6 +35,6 @@ const smartAccount = new SmartAccount(provider, {
 
 // Sets wallet UI to use AA mode
 particle.setERC4337({
-  name: 'SIMPLE',
-  version: '1.0.0',
+  name: 'SIMPLE', // or BICONOMY
+  version: '1.0.0', // If you're using BICONOMY, set to 2.0.0
 });

--- a/builders/integrations/wallets/particle-network.md
+++ b/builders/integrations/wallets/particle-network.md
@@ -117,8 +117,8 @@ If you want to use an ERC-4337 AA, you'll need to take a couple additional steps
 
 1. Import `SmartAccount` from [`@particle-network/aa`](https://docs.particle.network/developers/account-abstraction/sdks/web){target=_blank} and `ParticleProvider` from [`@particle-network/auth`](https://docs.particle.network/developers/auth-service/sdks/web){target=_blank}
 2. Initialize a `ParticleProvider` to handle wallet connect requests using the `particle` instance you created in the previous set of steps
-3. Initialize a [`SmartAccount`](https://docs.particle.network/developers/account-abstraction/sdks/web#initialize-the-smartaccount){target=_blank} using the provider, your project credentials, and the AA implementation and configuration. For Moonbeam, you'll use the `simple` implementation and pass in Moonbeam's chain ID
-4. Enable ERC-4337 mode, specifying the `SIMPLE` implementation
+3. Initialize a [`SmartAccount`](https://docs.particle.network/developers/account-abstraction/sdks/web#initialize-the-smartaccount){target=_blank} using the provider, your project credentials, and the AA implementation and configuration. For Moonbeam, you'll use either the `SIMPLE` or `BICONOMY` implementation (if you're using `BICOMOMY`, set `version` to `2.0.0`) and pass in Moonbeam's chain ID
+4. Enable ERC-4337 mode, specifying the `SIMPLE` or `BICONOMY` implementation
 
 ```js hl_lines="3 4 21-34 37-40"
 --8<-- 'code/builders/integrations/wallets/particle/configure-aa.js'


### PR DESCRIPTION
### Description

This PR makes a minor update to the Particle Network tutorial reflecting the fact that Particle now supports the Biconomy V2 smart account on Moonbeam, not only SimpleAccount (as was previously described within this tutorial). This includes an edit to the associated code snippet.

