### PR TITLE
Add ape docs

### DIFF
--- a/.snippets/code/builders/build/eth-api/dev-env/ape/Box.sol
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/Box.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT 
+pragma solidity ^0.8.1;
+
+contract Box {
+    uint256 private value;
+
+    event ValueChanged(uint256 newValue);
+
+    function store(uint256 newValue) public {
+        value = newValue;
+        emit ValueChanged(newValue);
+    }
+
+    function retrieve() public view returns (uint256) {
+        return value;
+    }
+}

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/conftest.py
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def owner(accounts):
+    return accounts[0]
+
+
+@pytest.fixture
+def box(owner, project):
+    return owner.deploy(project.Box)

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/deploy.py
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/deploy.py
@@ -1,4 +1,3 @@
-# scripts/deploy.py
 from ape import project, accounts
 
 

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/deploy.py
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/deploy.py
@@ -1,0 +1,9 @@
+# scripts/deploy.py
+from ape import project, accounts
+
+
+def main():
+    # Load your account by its name
+    account = accounts.load("alice")
+    # Deploy the contract using your account
+    return account.deploy(project.Box)

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/store-and-retrieve.py
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/store-and-retrieve.py
@@ -1,10 +1,9 @@
-# scripts/store-and-retrieve.py
 from ape import Contract, accounts
 
 
 def main():
     account = accounts.load("alice")
-    box = Contract("0x68039277300E8B104dDf848029dCA04C2EFe8610")
+    box = Contract("INSERT_CONTRACT_ADDRESS")
     store = box.store(4, sender=account)
     print("Transaction hash for updating the stored value:", store.txn_hash)
 

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/store-and-retrieve.py
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/store-and-retrieve.py
@@ -1,0 +1,12 @@
+# scripts/store-and-retrieve.py
+from ape import Contract, accounts
+
+
+def main():
+    account = accounts.load("alice")
+    box = Contract("0x68039277300E8B104dDf848029dCA04C2EFe8610")
+    store = box.store(4, sender=account)
+    print("Transaction hash for updating the stored value:", store.txn_hash)
+
+    retrieve = box.retrieve()
+    print("Stored value:", retrieve)

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/compile.md
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/compile.md
@@ -1,0 +1,5 @@
+<div id="termynal" data-termynal>
+    <span data-ty="input"><span class="file-path"></span>ape compile</span>
+    <span data-ty>INFO: Compiling 'Box.sol'.</span>
+    <span data-ty>INFO: Compiling using Solidity compiler '0.8.23+commit.f704f362'.</span>
+</div>

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/deploy.md
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/deploy.md
@@ -1,0 +1,23 @@
+<div id="termynal" data-termynal>
+    <span data-ty="input"><span class="file-path"></span>ape run deploy --network https://rpc.api.moonbase.moonbeam.network</span>
+    <span data-ty>INFO: Connecting to a 'moonbase' node.</span>
+    <br>
+    <span data-ty>DynamicFeeTransaction:</span>
+    <span data-ty>  chainId: 1287</span>
+    <span data-ty>  from: 0x097D9Eea23DE2D3081169e0225173d0C55768338</span>
+    <span data-ty>  gas: 123964</span>
+    <span data-ty>  nonce: 372</span>
+    <span data-ty>  value: 0</span>
+    <span data-ty>  data: 0x307836...303333</span>
+    <span data-ty>  type: 2</span>
+    <span data-ty>  maxFeePerGas: 125000000</span>
+    <span data-ty>  maxPriorityFeePerGas: 0</span>
+    <span data-ty>  accessList: []</span>
+    <br>
+    <span data-ty>Sign:  [y/N]: y</span>
+    <span data-ty>Enter passphrase to unlock 'alice' []:</span>
+    <span data-ty>Leave 'alice' unlocked? [y/N]: n</span>
+    <span data-ty>INFO: Confirmed 0x365cd903e7fac5ad1f815d7a6f211b1aa32bd7d78630c2e81d67514cfb9e55bb (total fees paid = 15326250000000)</span>
+    <span data-ty>SUCCESS: Contract 'Box' deployed to: 0x68039277300E8B104dDf848029dCA04C2EFe8610</span>
+ </span>
+</div>

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/init.md
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/init.md
@@ -1,0 +1,9 @@
+<div id="termynal" data-termynal>
+    <span data-ty="input"><span class="file-path"></span>ape init</span>
+    <span data-ty>Please enter project name: ape-demo</span>
+    <br>
+    <span data-ty>SUCCESS: ape-demo is written in ape-config.yaml</span>
+    <br>
+    <span data-ty="input"><span class="file-path"></span>ls</span>
+    <span data-ty>ape-config.yaml  contracts  scripts  tests</span>
+</div>

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/list-networks.md
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/list-networks.md
@@ -1,0 +1,14 @@
+<div id="termynal" data-termynal>
+    <span data-ty="input"><span class="file-path"></span>ape networks list</span>
+    <br>
+    <span data-ty>ethereum  (default)</span>
+    <span data-ty>├── goerli</span>
+    <span data-ty>│   └── geth  (default)</span>
+    <span data-ty>├── local  (default)</span>
+    <span data-ty>│   ├── geth</span>
+    <span data-ty>│   └── test  (default)</span>
+    <span data-ty>├── mainnet</span>
+    <span data-ty>│   └── geth  (default)</span>
+    <span data-ty>├── sepolia</span>
+    <span data-ty>│   └── geth  (default)</span>
+</div>

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/load.md
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/load.md
@@ -1,0 +1,7 @@
+<div id="termynal" data-termynal>
+    <span data-ty="input"><span class="file-path"></span>ape console --network https://rpc.api.moonbase.moonbeam.network</span>
+    <span data-ty>INFO: Connecting to a 'moonbase' node.</span>
+    <br>
+    <span data-ty="input" data-ty-prompt="In [1]:"> alice = accounts.load("alice")</span>
+    <span data-ty="input" data-ty-prompt="In [2]:"> box = Contract("0x68039277300E8B104dDf848029dCA04C2EFe8610")</span>
+</div>

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/new-account.md
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/new-account.md
@@ -1,0 +1,7 @@
+<div id="termynal" data-termynal>
+    <span data-ty="input"><span class="file-path"></span>ape accounts import alice</span>
+    <span data-ty>Enter Private Key:</span>
+    <span data-ty>Create Passphrase to encrypt account:</span>
+    <span data-ty>Repeat for confirmation:</span>
+    <span data-ty>SUCCESS: A new account '0x097D9Eea23DE2D3081169e0225173d0C55768338' has been added with the id 'alice'</span>
+</div>

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/retrieve.md
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/retrieve.md
@@ -1,0 +1,4 @@
+<div id="termynal" data-termynal>
+    <span data-ty="input" data-ty-prompt="In [4]:"> contract.retrieve()</span>
+    <span data-ty="input" data-ty-prompt="Out [4]:"> 4</span>
+</div>

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/store-and-retrieve.md
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/store-and-retrieve.md
@@ -1,0 +1,22 @@
+<div id="termynal" data-termynal>
+    <span data-ty="input"><span class="file-path"></span>ape run store-and-retrieve --network https://rpc.api.moonbase.moonbeam.network</span>
+    <span data-ty>DynamicFeeTransaction:</span>
+    <span data-ty>  chainId: 1287</span>
+    <span data-ty>  to: 0x68039277300E8B104dDf848029dCA04C2EFe8610</span>
+    <span data-ty>  from: 0x097D9Eea23DE2D3081169e0225173d0C55768338</span>
+    <span data-ty>  gas: 25974</span>
+    <span data-ty>  nonce: 374</span>
+    <span data-ty>  value: 0</span>
+    <span data-ty>  data: 0x307836...303035</span>
+    <span data-ty>  type: 2</span>
+    <span data-ty>  maxFeePerGas: 125000000</span>
+    <span data-ty>  maxPriorityFeePerGas: 0</span>
+    <span data-ty>  accessList: []</span>
+    <br>
+    <span data-ty>Sign:  [y/N]: y</span>
+    <span data-ty>Enter passphrase to unlock 'alice' []:</span>
+    <span data-ty>Leave 'alice' unlocked? [y/N]: n</span>
+    <span data-ty>INFO: Confirmed 0x6d74e48c23fd48438bf48baad34e235693c737bd880ef0077c0fb996f3896f5f (total fees paid = 3086250000000)</span>
+    <span data-ty>Transaction hash for updating the stored value:  0x6d74e48c23fd48438bf48baad34e235693c737bd880ef0077c0fb996f3896f5f</span>
+    <span data-ty>Stored value: 5</span>
+</div>

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/store.md
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/store.md
@@ -1,0 +1,21 @@
+<div id="termynal" data-termynal>
+    <span data-ty="input" data-ty-prompt="In [3]:"> box.store(4, sender=alice)</span>
+    <span data-ty>DynamicFeeTransaction:</span>
+    <span data-ty>  chainId: 1287</span>
+    <span data-ty>  to: 0x68039277300E8B104dDf848029dCA04C2EFe8610</span>
+    <span data-ty>  from: 0x097D9Eea23DE2D3081169e0225173d0C55768338</span>
+    <span data-ty>  gas: 45668</span>
+    <span data-ty>  nonce: 373</span>
+    <span data-ty>  value: 0</span>
+    <span data-ty>  data: 0x307836...303034</span>
+    <span data-ty>  type: 2</span>
+    <span data-ty>  maxFeePerGas: 125000000</span>
+    <span data-ty>  maxPriorityFeePerGas: 0</span>
+    <span data-ty>  accessList: []</span>
+    <br>
+    <span data-ty>Sign:  [y/N]: y</span>
+    <span data-ty>Enter passphrase to unlock 'alice' []:</span>
+    <span data-ty>Leave 'alice' unlocked? [y/N]: n</span>
+    <span data-ty>INFO: Confirmed 0xd2e8305f22f33c1ab8ccaaef94252a93ff0f69c9bf98503fc2744bf257f1ef67 (total fees paid = 5573750000000)</span>
+    <span data-ty="input" data-ty-prompt="Out [3]:"> Receipt 0xd2e8305f22f33c1ab8ccaaef94252a93ff0f69c9bf98503fc2744bf257f1ef67</span>
+</div>

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/test.md
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/terminal/test.md
@@ -1,0 +1,12 @@
+<div id="termynal" data-termynal>
+    <span data-ty="input"><span class="file-path"></span>ape test</span>
+    <span data-ty>===================== test session starts ======================</span>
+    <span data-ty>platform darwin -- Python 3.10.4, pytest-7.2.1, pluggy-1.4.0</span>
+    <span data-ty>rootdir: /Users/moonbeam/ape</span>
+    <span data-ty>plugins: eth-ape-0.7.7, web3-6.15.1</span>
+    <span data-ty>collected 1 item</span>
+    <br>
+    <span data-ty>tests/test_box.py .                                      [100%]</span>
+    <br>
+    <span data-ty>====================== 1 passed in 0.70s =======================</span>
+</div>

--- a/.snippets/code/builders/build/eth-api/dev-env/ape/test_box.py
+++ b/.snippets/code/builders/build/eth-api/dev-env/ape/test_box.py
@@ -1,0 +1,4 @@
+def test_store_value(box, owner):
+    new_value = 5
+    box.store(new_value, sender=owner)
+    assert box.retrieve() == new_value

--- a/builders/build/eth-api/dev-env/.pages
+++ b/builders/build/eth-api/dev-env/.pages
@@ -2,6 +2,7 @@ title: Dev Environments
 nav:
   - index.md
   - openzeppelin
+  - "Ape": "ape.md"
   - "Brownie": "brownie.md"
   - "Foundry": "foundry.md"
   - "Hardhat": "hardhat.md"

--- a/builders/build/eth-api/dev-env/ape.md
+++ b/builders/build/eth-api/dev-env/ape.md
@@ -1,0 +1,333 @@
+---
+title: Deploy Contracts with Ape
+description: Use Ape, a Python framework, to compile, deploy, and debug smart contracts using Python on Moonbeam, thanks to its Ethereum compatibility.
+---
+
+# Using Ape to Deploy To Moonbeam
+
+## Introduction {: #introduction }
+
+[Ape](https://docs.apeworx.io/ape/stable/){target=\_blank} is an Ethereum development environment that helps Python developers manage and automate the recurring tasks inherent to building smart contracts and DApps. Ape can directly interact with Moonbeam's Ethereum API, so you can also use Ape to deploy smart contracts on Moonbeam.
+
+This guide will walk you through using Ape to compile, deploy, and interact with Ethereum smart contracts on the Moonbase Alpha TestNet. You can adapt this guide for Moonbeam, Moonriver, or a Moonbeam development node.
+
+## Checking Prerequisites {: #checking-prerequisites }
+
+To get started, ensure you have the following:
+
+ - MetaMask installed and [connected to Moonbase Alpha](/tokens/connect/metamask/){target=\_blank}
+ - An account with funds.
+  --8<-- 'text/_common/faucet/faucet-list-item.md'
+ - 
+--8<-- 'text/_common/endpoint-examples-list-item.md'
+
+## Creating an Ape Project {: #creating-an-ape-project }
+
+If you don't already have an Ape project, you must install Ape and create a new one. You can follow the steps below to get started and create an empty project:
+
+1. Create a directory for your project
+
+    ```bash
+    mkdir ape && cd ape
+    ```
+
+2. If you don't have `pipx` installed, install it
+
+    ```bash
+    python3 -m pip install --user pipx
+    python3 -m pipx ensurepath
+    ```
+
+3. [Install Ape using `pipx`](https://ape.readthedocs.io/en/stable/install.html){target=\_blank}
+
+    ```bash
+    pipx install eth-ape
+    ```
+
+4. Create a project
+
+    ```bash
+    ape init
+    ```
+
+5. Enter a name for your project
+
+    --8<-- 'code/builders/build/eth-api/dev-env/ape/terminal/init.md'
+
+Your Ape project contains a bare-bones `ape-config.yaml` file for customizing specific settings and the following empty directories:
+
+- `contracts` - an empty directory for storing smart contracts
+- `scripts` - an empty directory for storing Python scripts, such as deployment scripts and scripts to interact with your deployed contracts
+- `tests` - an empty directory for `pytest` testing scripts
+
+## Configure Accounts {: #configure-accounts }
+
+You'll need to import an account before you can deploy smart contracts or interact with previously deployed contracts from your Ape project. You can run the following command, which will import your account and give it a name:
+
+```bash
+ape accounts import INSERT_ACCOUNT_NAME
+```
+
+You'll then be prompted to enter your private key and add a password to encrypt your account.
+
+--8<-- 'code/builders/build/eth-api/dev-env/ape/terminal/new-account.md'
+
+!!! note
+    If you wish to use a mnemonic instead, you can append the `--use-mnemonic` option to the import command.
+
+## Create Smart Contracts {: #the-contract-file }
+
+Now that you have set up your account, you can start writing smart contracts. As a basic example, you can use the following `Box` contract to store a value you can retrieve later.
+
+Start by creating a file named `Box.sol` inside the contracts directory:
+
+```bash
+touch contracts/Box.sol
+```
+
+Open the file and add the following contract to it:
+
+```solidity
+// contracts/Box.sol
+pragma solidity ^0.8.1;
+
+contract Box {
+    uint256 private value;
+
+    event ValueChanged(uint256 newValue);
+
+    function store(uint256 newValue) public {
+        value = newValue;
+        emit ValueChanged(newValue);
+    }
+
+    function retrieve() public view returns (uint256) {
+        return value;
+    }
+}
+```
+
+You can store any additional contracts in the `contracts` directory. 
+
+## Compile the Solidity Contract {: #compiling-solidity }
+
+Before compiling the Solidity, you must install the Solidity compiler plugin. Running the following command will install the latest version of the plugin:
+
+```bash
+ape plugins install solidity
+```
+
+To use a specific version of Solidity or a specific EVM version, you can modify your `ape-config.yaml` file as follows:
+
+```yaml
+solidity:
+  version: INSERT_VERSION
+  evm_version: INSERT_VERSION
+```
+
+For more information on the Solidity plugin, please refer to the [README of the `ape-solidity` repository on GitHub](https://github.com/ApeWorX/ape-solidity/blob/main/README.md){target=_blank}.
+
+With the Solidity plugin installed, the next step is to compile the smart contract:
+
+```bash
+ape compile
+```
+
+--8<-- 'code/builders/build/eth-api/dev-env/ape/terminal/compile.md'
+
+After compilation, you can find the bytecode and ABI for your contracts in the `.build` directory.
+
+## Deploy the Contract {: #deploy-the-contract }
+
+To deploy your contracts, create a deployment script named `deploy.py` inside of the `scripts` directory:
+
+```bash
+touch scripts/deploy.py
+```
+
+Next, you'll need to write the deployment script. You'll need to load the account you will use to deploy the contract and access it by its name using the project manager.
+
+```python
+# scripts/deploy.py
+from ape import project, accounts
+
+def main():
+    # Load your account by its name
+    account = accounts.load("alice")
+    # Deploy the contract using your account
+    return account.deploy(project.Box)
+```
+
+Now you're ready to deploy the `Box` contract!
+--8<-- 'text/_common/endpoint-setup.md'
+
+Take the following steps to initiate and send the deployment transaction:
+
+1. Run the deployment script using the `ape run deploy` command
+
+    === "Moonbeam"
+
+        ```bash
+        ape run deploy --network {{ networks.moonbeam.rpc_url }}
+        ```
+
+    === "Moonriver"
+
+        ```bash
+        ape run deploy --network {{ networks.moonriver.rpc_url }}
+        ```
+
+    === "Moonbase Alpha"
+
+        ```bash
+        ape run deploy --network {{ networks.moonbase.rpc_url }}
+        ```
+
+    === "Moonbeam Dev Node"
+
+        ```bash
+        ape run deploy --network {{ networks.development.rpc_url }}
+        ``` 
+
+    !!! note
+        For the `ape run deploy` command to work as intended, the deployment script must be named `deploy.py` and stored in the `scripts` directory, and the script must define a `main()` method.
+
+2. Review the transaction details and enter **y** to sign the transaction
+3. Enter your passphrase for your account
+4. Enter **y** to leave your account unlocked or **n** to lock it
+
+After you follow the prompts and submit the transaction, the transaction hash, total fees paid, and contract address will be displayed in the terminal.
+
+--8<-- 'code/builders/build/eth-api/dev-env/ape/terminal/deploy.md'
+
+Congratulations! Your contract is live! Save the address to interact with your contract in the following section.
+
+## Interact with the Contract {: #interact-with-the-contract }
+
+You can interact with contracts using the Ape console for quick debugging and testing, or write a script.
+
+### Using The Ape Console {: #using-ape-console }
+
+To interact with your newly deployed contract, you can launch the Ape console by running:
+
+=== "Moonbeam"
+
+    ```bash
+    ape console --network {{ networks.moonbeam.rpc_url }}
+    ```
+
+=== "Moonriver"
+
+    ```bash
+    ape console --network {{ networks.moonriver.rpc_url }}
+    ```
+
+=== "Moonbase Alpha"
+
+    ```bash
+    ape console --network {{ networks.moonbase.rpc_url }}
+    ```
+
+=== "Moonbeam Dev Node"
+
+    ```bash
+    ape console --network {{ networks.development.rpc_url }}
+    ``` 
+
+Next, you'll need to create a contract instance using the contract's address:
+
+```bash
+box = Contract("INSERT_CONTRACT_ADDRESS")
+```
+
+--8<-- 'code/builders/build/eth-api/dev-env/ape/terminal/load.md'
+
+Now, you can interact with your contract instance! For example, you can set the variable to be stored in the `Box` contract using the following commands:
+
+1. Call the `store` method by passing in a value to store and the account you want to use to send the transaction:
+
+    ```bash
+    box.store(4, sender=alice)
+    ```
+
+2. Review the transaction details and enter **y** to sign the transaction
+3. If you previously locked your account, you must enter your passphrase to unlock it. Otherwise, Ape will use the cached key for your account
+4. If you unlocked your account in the previous step, you'll be asked if you want to leave your account unlocked. You can enter **y** to leave it unlocked or **n** to lock it
+
+After you follow the prompts and submit the transaction, the transaction hash and total fees paid will be displayed in the terminal.
+
+--8<-- 'code/builders/build/eth-api/dev-env/ape/terminal/store.md'
+
+Then, you can retrieve the stored value by calling the `retrieve` method:
+
+```bash
+box.retrieve()
+```
+
+The number you just stored in the previous steps will be printed to the console.
+
+--8<-- 'code/builders/build/eth-api/dev-env/ape/terminal/retrieve.md'
+
+## Using a Script {: #using-a-script }
+
+You can also write a script to interact with your newly deployed contract. To get started, you can create a new file in the `scripts` directory:
+
+```bash
+touch scripts/store-and-retrieve.py
+```
+
+Next, you can write a script that stores and retrieves a value. To get started, take the following steps:
+
+```python
+# scripts/store-and-retrieve.py
+from ape import Contract, accounts
+
+def main():
+    account = accounts.load("alice")
+    box = Contract("0x68039277300E8B104dDf848029dCA04C2EFe8610")
+    store = box.store(4, sender=account)
+    print("Transaction hash for updating the stored value: ", store.txn_hash)
+
+    retrieve = box.retrieve()
+    print("Stored value: ", retrieve)
+```
+
+Now, you can run the script to set the stored value and retrieve it:
+
+1. Run the script
+
+    === "Moonbeam"
+
+        ```bash
+        ape run store-and-retrieve --network {{ networks.moonbeam.rpc_url }}
+        ```
+
+    === "Moonriver"
+
+        ```bash
+        ape run store-and-retrieve --network {{ networks.moonriver.rpc_url }}
+        ```
+
+    === "Moonbase Alpha"
+
+        ```bash
+        ape run store-and-retrieve --network {{ networks.moonbase.rpc_url }}
+        ```
+
+    === "Moonbeam Dev Node"
+
+        ```bash
+        ape run store-and-retrieve --network {{ networks.development.rpc_url }}
+        ```
+
+2. Review the transaction details and enter **y** to sign the transaction
+3. If you previously locked your account, you must enter your passphrase to unlock it. Otherwise, Ape will use the cached key for your account
+4. If you unlocked your account in the previous step, you'll be asked if you want to leave your account unlocked. You can enter **y** to leave it unlocked or **n** to lock it
+
+Once completed, you should see a transaction hash and a value of `4` printed to the console.
+
+--8<-- 'code/builders/build/eth-api/dev-env/ape/terminal/store-and-retrieve.md'
+
+Congratulations! You have successfully deployed and interacted with a contract using Ape!
+
+--8<-- 'text/_disclaimers/third-party-content.md'

--- a/builders/build/eth-api/dev-env/ape.md
+++ b/builders/build/eth-api/dev-env/ape.md
@@ -88,26 +88,10 @@ touch contracts/Box.sol
 Open the file and add the following contract to it:
 
 ```solidity
-// contracts/Box.sol
-pragma solidity ^0.8.1;
-
-contract Box {
-    uint256 private value;
-
-    event ValueChanged(uint256 newValue);
-
-    function store(uint256 newValue) public {
-        value = newValue;
-        emit ValueChanged(newValue);
-    }
-
-    function retrieve() public view returns (uint256) {
-        return value;
-    }
-}
+--8<-- 'code/builders/build/eth-api/dev-env/ape/Box.sol'
 ```
 
-You can store any additional contracts in the `contracts` directory. 
+You can store any additional contracts in the `contracts` directory.
 
 ## Compile the Solidity Contract {: #compiling-solidity }
 
@@ -148,14 +132,7 @@ touch scripts/deploy.py
 Next, you'll need to write the deployment script. You'll need to load the account you will use to deploy the contract and access it by its name using the project manager.
 
 ```python
-# scripts/deploy.py
-from ape import project, accounts
-
-def main():
-    # Load your account by its name
-    account = accounts.load("alice")
-    # Deploy the contract using your account
-    return account.deploy(project.Box)
+--8<-- 'code/builders/build/eth-api/dev-env/ape/deploy.py'
 ```
 
 Now you're ready to deploy the `Box` contract!
@@ -279,17 +256,7 @@ touch scripts/store-and-retrieve.py
 Next, you can write a script that stores and retrieves a value. To get started, take the following steps:
 
 ```python
-# scripts/store-and-retrieve.py
-from ape import Contract, accounts
-
-def main():
-    account = accounts.load("alice")
-    box = Contract("0x68039277300E8B104dDf848029dCA04C2EFe8610")
-    store = box.store(4, sender=account)
-    print("Transaction hash for updating the stored value: ", store.txn_hash)
-
-    retrieve = box.retrieve()
-    print("Stored value: ", retrieve)
+--8<-- 'code/builders/build/eth-api/dev-env/ape/deploy.py'
 ```
 
 Now, you can run the script to set the stored value and retrieve it:

--- a/builders/build/eth-api/dev-env/ape.md
+++ b/builders/build/eth-api/dev-env/ape.md
@@ -58,7 +58,7 @@ Your Ape project contains a bare-bones `ape-config.yaml` file for customizing sp
 
 - `contracts` - an empty directory for storing smart contracts
 - `scripts` - an empty directory for storing Python scripts, such as deployment scripts and scripts to interact with your deployed contracts
-- `tests` - an empty directory for `pytest` testing scripts
+- `tests` - an empty directory for pytest testing scripts
 
 ## Configure Accounts {: #configure-accounts }
 
@@ -121,6 +121,52 @@ ape compile
 
 After compilation, you can find the bytecode and ABI for your contracts in the `.build` directory.
 
+## Test the Contract {: #test-the-contract }
+
+Before you deploy your contract, you can test it out directly inside your Ape project using the [pytest framework](https://docs.pytest.org/en/latest/){target=\_blank} to make sure it works as you expect.
+
+You should already have a `tests` directory where you'll create your tests, but if not, please create one, as all tests must be located in a directory named `tests`. Additionally, each test file name must start with `test_` and end with `.py`. So, first, you can create a test file for the `Box.sol` contract:
+
+```bash
+touch tests/test_box.py
+```
+
+In addition to the test file, you can create a `conftest.py` file that will define a couple of essential [fixtures](https://docs.pytest.org/en/stable/explanation/fixtures.html){target=\_blank}. Fixtures allow you to define functions that set up the necessary environment or resources to run your tests. Note that while the `Box.sol` contract is simple, incorporating fixtures into your testing process is good practice.
+
+To create the file, you can run the following command:
+
+```bash
+touch tests/conftest.py
+```
+
+Since your tests will rely on the injection of the fixtures, you must define the fixtures first. When defining fixtures, you need to apply the `pytest.fixture` decorator above each function. For this example, you'll create two fixtures: one that defines the owner of the contract and one that deploys the contract from the owner's account.
+
+The `owner` fixture will use the built-in `accounts` fixture to take the first account in the list of test accounts provided by Ape and return it. The `box` fixture will deploy the `Box` contract type using the built-in `project` fixture, you simply have to provide the name of the contract and use the `owner` fixture to deploy it.
+
+```python title="tests/conftest.py"
+--8<-- 'code/builders/build/eth-api/dev-env/ape/conftest.py'
+```
+
+Now that you've created the fixtures, you can start creating your tests. Each test function name must start with `test_` and describe what the test does. For this example, you can use `test_store_value`, as you'll create a test for the `store` function. The test will store a value and then retrieve it, asserting that the retrieved value is equal to the value passed into the `store` function.
+
+To use the `owner` and `box` fixtures, you must pass them into your test function, which will inject the fixtures automatically for you to use. The `owner` account will be used to call the `store` function of the `box` contract instance.
+
+```py title="tests/test_box.py"
+--8<-- 'code/builders/build/eth-api/dev-env/ape/test_box.py'
+```
+
+And that's it! That's all you'll need inside your test file. You can use the following command to run the test:
+
+```bash
+ape test
+```
+
+The results of running the test will be printed to the terminal.
+
+--8<-- 'code/builders/build/eth-api/dev-env/ape/terminal/test.md'
+
+Now that you have confidence in your contract, the next step is to deploy it.
+
 ## Deploy the Contract {: #deploy-the-contract }
 
 To deploy your contracts, create a deployment script named `deploy.py` inside of the `scripts` directory:
@@ -131,7 +177,7 @@ touch scripts/deploy.py
 
 Next, you'll need to write the deployment script. You'll need to load the account you will use to deploy the contract and access it by its name using the project manager.
 
-```python
+```python title="scripts/deploy.py"
 --8<-- 'code/builders/build/eth-api/dev-env/ape/deploy.py'
 ```
 
@@ -245,7 +291,7 @@ The number you just stored in the previous steps will be printed to the console.
 
 --8<-- 'code/builders/build/eth-api/dev-env/ape/terminal/retrieve.md'
 
-## Using a Script {: #using-a-script }
+### Using a Script {: #using-a-script }
 
 You can also write a script to interact with your newly deployed contract. To get started, you can create a new file in the `scripts` directory:
 
@@ -253,10 +299,10 @@ You can also write a script to interact with your newly deployed contract. To ge
 touch scripts/store-and-retrieve.py
 ```
 
-Next, you can write a script that stores and retrieves a value. To get started, take the following steps:
+Next, you can write a script that stores and retrieves a value. Note that when creating a contract instance to interact with, you must pass in the address of the deployed contract.
 
-```python
---8<-- 'code/builders/build/eth-api/dev-env/ape/deploy.py'
+```python title="scripts/store-and-retrieve.py"
+--8<-- 'code/builders/build/eth-api/dev-env/ape/store-and-retrieve.py'
 ```
 
 Now, you can run the script to set the stored value and retrieve it:

--- a/builders/get-started/quick-start.md
+++ b/builders/get-started/quick-start.md
@@ -111,6 +111,7 @@ As Moonbeam is a Substrate-based chain that is fully Ethereum-compatible, you ca
     |                                Tool                                 |      Type       |
     |:-------------------------------------------------------------------:|:---------------:|
     | [Web3.py](/builders/build/eth-api/libraries/web3py){target=\_blank} |     Library     |
+    |     [Ape](/builders/build/eth-api/dev-env/ape){target=\_blank}      | Dev Environment |
     | [Brownie](/builders/build/eth-api/dev-env/brownie){target=\_blank}  | Dev Environment |
     |   [thirdweb](https://portal.thirdweb.com/python){target=\_blank}    | Dev Environment |
 


### PR DESCRIPTION
### Description

This PR adds docs for Ape. Since Brownie is no longer being maintained, I figured we should have docs for an alternative solution for python developers.

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] I have run my changes through Grammarly
- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [x] If this page requires a disclaimer, I have added one

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
