### PR TITLE
Uses chain decimals docs

### DIFF
--- a/builders/interoperability/xcm/xcm-sdk/v1/reference.md
+++ b/builders/interoperability/xcm/xcm-sdk/v1/reference.md
@@ -54,6 +54,7 @@ The XCM SDK is based on the premise of defining an asset to transfer and then de
     | `genesisHash` |            *string*            |                                  The hash of the genesis block                                   |
     | `parachainId` |            *number*            |                                     The ID of the parachain                                      |
     | `ss58Format`  |            *number*            | The [ss58 format](https://polkadot.js.org/docs/keyring/start/ss58/){target=\_blank} for the chain |
+    | `usesChainDecimals` |            *string*            |A flag indicating if the chains uses it's own decimals in balance queries for all the assets. Defaults as `false`
     |     `ws`      |            *string*            |                               The WebSocket endpoint for the chain                               |
     |     `id`      |            *number*            |                            **For EVM parachains only** - The chain ID                            |
     |     `rpc`     |            *string*            |                **For EVM parachains only** - The HTTP RPC endpoint for the chain                 |

--- a/builders/interoperability/xcm/xcm-sdk/v1/reference.md
+++ b/builders/interoperability/xcm/xcm-sdk/v1/reference.md
@@ -54,7 +54,7 @@ The XCM SDK is based on the premise of defining an asset to transfer and then de
     | `genesisHash` |            *string*            |                                  The hash of the genesis block                                   |
     | `parachainId` |            *number*            |                                     The ID of the parachain                                      |
     | `ss58Format`  |            *number*            | The [ss58 format](https://polkadot.js.org/docs/keyring/start/ss58/){target=\_blank} for the chain |
-    | `usesChainDecimals` |            *string*            |A flag indicating if the chains uses it's own decimals in balance queries for all the assets. Defaults as `false`
+    | `usesChainDecimals` |            *string*            |A flag indicating if the chain uses its own decimals in balance queries for all the assets. Defaults as `false`
     |     `ws`      |            *string*            |                               The WebSocket endpoint for the chain                               |
     |     `id`      |            *number*            |                            **For EVM parachains only** - The chain ID                            |
     |     `rpc`     |            *string*            |                **For EVM parachains only** - The HTTP RPC endpoint for the chain                 |


### PR DESCRIPTION
### Description

We added a new parameter for the chain configuration in the SDK for a new edge case.
The edge case is Zeitgeist, which internally uses 10 decimals in the balance queries for all the assets regardless of the assets' decimals. 

### Checklist

- [ ] I have added a label to this PR 🏷️
- [x] I have run my changes through Grammarly
- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [x] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [x] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [x] If images have been added, I have run the `compress-images.py` script to compress the images.
- [x] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [x] If this page requires a disclaimer, I have added one

### Corresponding PRs

https://github.com/moonbeam-foundation/xcm-sdk/pull/179

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

n/a