### PR TITLE
xcm sdk update: uses chain decimals

### DIFF
--- a/builders/interoperability/xcm/xcm-sdk/v1/reference.md
+++ b/builders/interoperability/xcm/xcm-sdk/v1/reference.md
@@ -43,21 +43,21 @@ The XCM SDK is based on the premise of defining an asset to transfer and then de
 
 - `Chain` - defines properties related to a chain, used to define the source and destination chains. If a chain is an EVM parachain, there are a couple additional properties
 
-    |     Name      |              Type              |                                           Description                                            |
-    |:-------------:|:------------------------------:|:------------------------------------------------------------------------------------------------:|
-    |  `ecosystem`  |          *Ecosystem*           |     Identifies the ecosystem the chain belongs to: `polkadot`, `kusama`, or `alphanet-relay`     |
-    | `isTestChain` |           *boolean*            |                                  Whether the chain is a TestNet                                  |
-    |     `key`     |            *string*            |                                        Identifies a chain                                        |
-    |    `name`     |            *string*            |                                      The name of the chain                                       |
-    |    `type`     |          *ChainType*           |                      The type of the chain: `parachain` or `evm-parachain`                       |
-    | `assetsData`  | *Map<string, ChainAssetsData>* |                           A list of the assets that the chain supports                           |
-    | `genesisHash` |            *string*            |                                  The hash of the genesis block                                   |
-    | `parachainId` |            *number*            |                                     The ID of the parachain                                      |
-    | `ss58Format`  |            *number*            | The [ss58 format](https://polkadot.js.org/docs/keyring/start/ss58/){target=\_blank} for the chain |
-    | `usesChainDecimals` |            *string*            |A flag indicating if the chain uses its own decimals in balance queries for all the assets. Defaults as `false`
-    |     `ws`      |            *string*            |                               The WebSocket endpoint for the chain                               |
-    |     `id`      |            *number*            |                            **For EVM parachains only** - The chain ID                            |
-    |     `rpc`     |            *string*            |                **For EVM parachains only** - The HTTP RPC endpoint for the chain                 |
+    |        Name         |              Type              |                                                   Description                                                   |
+    |:-------------------:|:------------------------------:|:---------------------------------------------------------------------------------------------------------------:|
+    |     `ecosystem`     |          *Ecosystem*           |            Identifies the ecosystem the chain belongs to: `polkadot`, `kusama`, or `alphanet-relay`             |
+    |    `isTestChain`    |           *boolean*            |                                         Whether the chain is a TestNet                                          |
+    |        `key`        |            *string*            |                                               Identifies a chain                                                |
+    |       `name`        |            *string*            |                                              The name of the chain                                              |
+    |       `type`        |          *ChainType*           |                              The type of the chain: `parachain` or `evm-parachain`                              |
+    |    `assetsData`     | *Map<string, ChainAssetsData>* |                                  A list of the assets that the chain supports                                   |
+    |    `genesisHash`    |            *string*            |                                          The hash of the genesis block                                          |
+    |    `parachainId`    |            *number*            |                                             The ID of the parachain                                             |
+    |    `ss58Format`     |            *number*            |        The [ss58 format](https://polkadot.js.org/docs/keyring/start/ss58/){target=\_blank} for the chain        |
+    | `usesChainDecimals` |           *boolean*            | A flag indicating if the chain uses its own decimals in balance queries for all the assets. Defaults to `false` |
+    |        `ws`         |            *string*            |                                      The WebSocket endpoint for the chain                                       |
+    |        `id`         |            *number*            |                                   **For EVM parachains only** - The chain ID                                    |
+    |        `rpc`        |            *string*            |                        **For EVM parachains only** - The HTTP RPC endpoint for the chain                        |
 
 - `ChainAssetsData` - defines the information needed to target the asset on the chain. This is mostly for internal usage to accommodate how different chains store their assets. The SDK defaults to the asset ID if certain properties are not applicable to the given chain
 
@@ -270,9 +270,9 @@ When building transfer data with the `Sdk().assets()` function, you'll use multi
 - `toDecimal()` - converts an `AssetAmount` to a decimal. The number to convert to decimal format and the number of decimals the asset uses are pulled automatically from the `AssetAmount`
 
     ??? code "Parameters"
-        |     Name      |      Type      |                                                                    Description                                                                    |
-        |:-------------:|:--------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------:|
-        | `maxDecimal?` |    *number*    |                                          The maximum number of decimal places to use. The default is `6`                                          |
+        |     Name      |      Type      |                                                                    Description                                                                     |
+        |:-------------:|:--------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------:|
+        | `maxDecimal?` |    *number*    |                                          The maximum number of decimal places to use. The default is `6`                                           |
         | `roundType?`  | *RoundingMode* | Accepts an index that dictates the [rounding method](https://mikemcl.github.io/big.js/#rm){target=\_blank} to use based on the `RoundingMode` enum |
 
         Where the `RoundingMode` enum is defined as:
@@ -304,9 +304,9 @@ When building transfer data with the `Sdk().assets()` function, you'll use multi
 - `toBigDecimal()` - converts an `AssetAmount` to a decimal and then to a big number. The number to convert to decimal format and the number of decimals the asset uses are pulled automatically from the `AssetAmount`
 
     ??? code "Parameters"
-        |     Name      |      Type      |                                                                    Description                                                                    |
-        |:-------------:|:--------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------:|
-        | `maxDecimal?` |    *number*    |                                          The maximum number of decimal places to use. The default is `6`                                          |
+        |     Name      |      Type      |                                                                    Description                                                                     |
+        |:-------------:|:--------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------:|
+        | `maxDecimal?` |    *number*    |                                          The maximum number of decimal places to use. The default is `6`                                           |
         | `roundType?`  | *RoundingMode* | Accepts an index that dictates the [rounding method](https://mikemcl.github.io/big.js/#rm){target=\_blank} to use based on the `RoundingMode` enum |
 
         Where the `RoundingMode` enum is defined as:

--- a/builders/interoperability/xcm/xcm-sdk/v1/xcm-sdk.md
+++ b/builders/interoperability/xcm/xcm-sdk/v1/xcm-sdk.md
@@ -443,6 +443,7 @@ As previously mentioned, regardless of which method you use to build the transfe
           genesisHash: '0xfe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d',
           parachainId: 2004,
           ss58Format: 1284,
+          usesChainDecimals: false,
           weight: 1000000000,
           ws: 'wss://wss.api.moonbeam.network',
           id: 1284,
@@ -504,6 +505,7 @@ As previously mentioned, regardless of which method you use to build the transfe
           genesisHash: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
           parachainId: 0,
           ss58Format: 0,
+          usesChainDecimals: false,
           weight: 1000000000,
           ws: 'wss://rpc.polkadot.io'
         },
@@ -620,6 +622,7 @@ The `swap` function returns the transfer data with the original source chain and
           genesisHash: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
           parachainId: 0,
           ss58Format: 0,
+          usesChainDecimals: false,
           weight: 1000000000,
           ws: 'wss://rpc.polkadot.io'
         },
@@ -693,6 +696,7 @@ The `swap` function returns the transfer data with the original source chain and
           genesisHash: '0xfe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d',
           parachainId: 2004,
           ss58Format: 1284,
+          usesChainDecimals: false,
           weight: 1000000000,
           ws: 'wss://wss.api.moonbeam.network',
           id: 1284,


### PR DESCRIPTION
### Description

This is an extension of #867; it applies formatting and updates the return examples on the using the xcm sdk page

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
