### PR TITLE
remove variable from snippet

### DIFF
--- a/.snippets/text/_common/async-backing-moonbase.md
+++ b/.snippets/text/_common/async-backing-moonbase.md
@@ -1,2 +1,2 @@
 !!! note
-    As of runtime 2800, [asynchronous backing](https://wiki.polkadot.network/docs/learn-async-backing){target=\_blank} has been enabled on Moonbase Alpha. As a result, the target block time was reduced from 12 seconds to {{ networks.moonbase.block_time }} seconds, which may break some timing-based assumptions. Note that this is for Moonbase Alpha only.
+    As of runtime 2800, [asynchronous backing](https://wiki.polkadot.network/docs/learn-async-backing){target=\_blank} has been enabled on Moonbase Alpha. As a result, the target block time was reduced from 12 seconds to 6 seconds, which may break some timing-based assumptions. Note that this is for Moonbase Alpha only.


### PR DESCRIPTION
### Description

This PR removes the block time variable from the snippet. Variables don't render correctly in snippets 

<img width="826" alt="Screenshot 2024-03-08 at 12 29 14 PM" src="https://github.com/moonbeam-foundation/moonbeam-docs/assets/26533957/ad86b4b6-5327-418e-ade0-09503413376a">

### Checklist

- [x] I have added a label to this PR 🏷️

