### PR TITLE
add the index page for the release section

### DIFF
--- a/builders/build/.pages
+++ b/builders/build/.pages
@@ -6,3 +6,4 @@ nav:
   - eth-api
   - substrate-api
   - 'Moonbeam Custom API': 'moonbeam-custom-api.md'
+  - releases # Hidden from left nav manually in nav-item and subsection-index-page overrides

--- a/builders/build/releases/index.md
+++ b/builders/build/releases/index.md
@@ -1,0 +1,8 @@
+---
+title: Runtime Release Notes
+description: Take a look at the runtime release notes for every Moonbeam runtime upgrade to uncover a concise overview of the latest updates and enhancements.
+template: subsection-index-page.html
+hide: 
+ - toc
+ - feedback
+---


### PR DESCRIPTION
### Description

This PR adds an index page for the release section of the docs and also adds that section to the `.pages` of the build section so that it can be picked up by mkdocs and can be manipulated as needed
Goes with: https://github.com/papermoonio/moonbeam-mkdocs/pull/178

### Checklist

- [x] I have added a label to this PR 🏷️
