### PR TITLE
Adding eth_getBlockReceipts and Batch request to rpc-support.md

### DIFF
--- a/builders/get-started/eth-compare/rpc-support.md
+++ b/builders/get-started/eth-compare/rpc-support.md
@@ -95,6 +95,6 @@ The supported methods from Geth's [debug](https://geth.ethereum.org/docs/interac
 
 For a dedicated tutorial for these debug and trace methods, check out the [Debug API & Trace Module](/builders/build/eth-api/debug-trace/){target=\_blank} guide.
 
-## Batch request {: #batch-request }
+## Batch Requests {: #batch-request }
 
 Moonbeam clients support [batch requests](https://geth.ethereum.org/docs/interacting-with-geth/rpc/batch){target=\_blank}, allowing you to send multiple data requests simultaneously in an array. This reduces network delays by fetching data in a single call, which is especially beneficial for retrieving large amounts of independent data.

--- a/builders/get-started/eth-compare/rpc-support.md
+++ b/builders/get-started/eth-compare/rpc-support.md
@@ -97,4 +97,4 @@ For a dedicated tutorial for these debug and trace methods, check out the [Debug
 
 ## Batch request {: #batch-request }
 
-Moonbeam clients support [Batch request](https://geth.ethereum.org/docs/interacting-with-geth/rpc/batch){target=\_blank}, allowing you to send multiple data requests simultaneously in an array. This reduces network delays by fetching data in a single call, especially beneficial for retrieving large amounts of independent data.
+Moonbeam clients support [batch requests](https://geth.ethereum.org/docs/interacting-with-geth/rpc/batch){target=\_blank}, allowing you to send multiple data requests simultaneously in an array. This reduces network delays by fetching data in a single call, which is especially beneficial for retrieving large amounts of independent data.

--- a/builders/get-started/eth-compare/rpc-support.md
+++ b/builders/get-started/eth-compare/rpc-support.md
@@ -30,7 +30,7 @@ The basic JSON-RPC methods from the Ethereum API supported by Moonbeam are:
 - **[eth_getStorageAt](https://eth.wiki/json-rpc/API#eth_getstorageat){target=\_blank}** — returns content of the storage at a given address
 - **[eth_getBlockByHash](https://eth.wiki/json-rpc/API#eth_getblockbyhash){target=\_blank}** — returns information about the block of the given hash including `baseFeePerGas` on post-London blocks
 - **[eth_getBlockByNumber](https://eth.wiki/json-rpc/API#eth_getblockbynumber){target=\_blank}** — returns information about the block specified by block number including `baseFeePerGas` on post-London blocks
-- **[eth_getBlockReceipts](https://docs.alchemy.com/reference/eth-getblockreceipts){target=\_blank}** — returns all transaction receipts for a given block.
+- **[eth_getBlockReceipts](https://docs.alchemy.com/reference/eth-getblockreceipts){target=\_blank}** — returns all transaction receipts for a given block
 - **[eth_getTransactionCount](https://eth.wiki/json-rpc/API#eth_gettransactioncount){target=\_blank}** — returns the number of transactions sent from the given address (nonce)
 - **[eth_getBlockTransactionCountByHash](https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbyhash){target=\_blank}** — returns the number of transactions in a block with a given block hash
 - **[eth_getBlockTransactionCountByNumber](https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbynumber){target=\_blank}** — returns the number of transactions in a block with a given block number

--- a/builders/get-started/eth-compare/rpc-support.md
+++ b/builders/get-started/eth-compare/rpc-support.md
@@ -30,6 +30,7 @@ The basic JSON-RPC methods from the Ethereum API supported by Moonbeam are:
 - **[eth_getStorageAt](https://eth.wiki/json-rpc/API#eth_getstorageat){target=\_blank}** — returns content of the storage at a given address
 - **[eth_getBlockByHash](https://eth.wiki/json-rpc/API#eth_getblockbyhash){target=\_blank}** — returns information about the block of the given hash including `baseFeePerGas` on post-London blocks
 - **[eth_getBlockByNumber](https://eth.wiki/json-rpc/API#eth_getblockbynumber){target=\_blank}** — returns information about the block specified by block number including `baseFeePerGas` on post-London blocks
+- **[eth_getBlockReceipts](https://docs.alchemy.com/reference/eth-getblockreceipts){target=\_blank}** — returns all transaction receipts for a given block.
 - **[eth_getTransactionCount](https://eth.wiki/json-rpc/API#eth_gettransactioncount){target=\_blank}** — returns the number of transactions sent from the given address (nonce)
 - **[eth_getBlockTransactionCountByHash](https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbyhash){target=\_blank}** — returns the number of transactions in a block with a given block hash
 - **[eth_getBlockTransactionCountByNumber](https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbynumber){target=\_blank}** — returns the number of transactions in a block with a given block number
@@ -93,3 +94,7 @@ The supported methods from Geth's [debug](https://geth.ethereum.org/docs/interac
 - **[txpool_status](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool-status){target=\_blank}** - returns the total number of transactions currently pending, waiting to be included in the next block(s), and queued for future execution
 
 For a dedicated tutorial for these debug and trace methods, check out the [Debug API & Trace Module](/builders/build/eth-api/debug-trace/){target=\_blank} guide.
+
+## Batch request {: #batch-request }
+
+Moonbeam clients support [Batch request](https://geth.ethereum.org/docs/interacting-with-geth/rpc/batch){target=\_blank}, allowing you to send multiple data requests simultaneously in an array. This reduces network delays by fetching data in a single call, especially beneficial for retrieving large amounts of independent data.


### PR DESCRIPTION
Adding description for eth_getBlockReceipts and Batch request

### Description
Adding description for RPC method eth_getBlockReceipts.

- note
*Both features are not basic Ethereum RPC method/feature*
*Both are supported on Moonbeam*
