### PR TITLE
update code snippet in remote evm tutorial

### DIFF
--- a/.snippets/code/builders/interoperability/xcm/remote-execution/remote-evm-calls/send.js
+++ b/.snippets/code/builders/interoperability/xcm/remote-execution/remote-evm-calls/send.js
@@ -35,12 +35,13 @@ const instr3 = {
 };
 const message = { V3: [instr1, instr2, instr3] };
 
-// 2. Create Keyring instance
-await cryptoWaitReady();
-const keyring = new Keyring({ type: 'sr25519' });
-const alice = keyring.addFromUri(privateKey);
 
 const sendXcmMessage = async () => {
+  // 2. Create Keyring instance
+  await cryptoWaitReady();
+  const keyring = new Keyring({ type: 'sr25519' });
+  const alice = keyring.addFromUri(privateKey);
+  
   // 3. Create Substrate API Provider
   const substrateProvider = new WsProvider(providerWsURL);
   const api = await ApiPromise.create({ provider: substrateProvider });


### PR DESCRIPTION
### Description

This PR updates one of the example snippets in the remote evm tutorial; it moves the `cryptoWaitReady` function into the asyn function.

It's a code snippet, so no need to worry about changing the CN repo.

### Checklist

- [x] I have added a label to this PR 🏷️

