### PR TITLE
minor update to the transact through sovereign function

### DIFF
--- a/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet.md
+++ b/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-pallet.md
@@ -157,7 +157,7 @@ The XCM Transactor Pallet provides the following extrinsics (functions):
     === "Parameters"
 
         - `dest` - the XCM versioned multilocation for a chain in the ecosystem where the XCM message is being sent to (the target chain)
-        - `feePayer` - the address that will pay for the remote XCM execution in the corresponding [XC-20 token](/builders/interoperability/xcm/xc20/overview/){target=\_blank}
+        - `feePayer` - (optional) the address that will pay for the remote XCM execution in the corresponding [XC-20 token](/builders/interoperability/xcm/xc20/overview/){target=\_blank}. If you don't specify the `feePayer`, the XCM execution fees will be paid by the Sovereign account on the destination chain
         - `fee` - the asset to be used for fees. This contains the `currency` and the `feeAmount`:
             - `currency` -  defines how you are specifying the token to use to pay for the fees, which can be either of the following:
                 - `AsCurrencyId` - the currency ID of the asset to use for the fees. The currency ID can be either:


### PR DESCRIPTION
### Description

As of runtime 2900, there was a slight change to the `transactThroughSovereign` function that switches the `feePayer` parameter to optional

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] I have run my changes through Grammarly

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
