### PR TITLE
Remove POKT network public endpoint info

### DIFF
--- a/.snippets/text/builders/get-started/endpoints/moonbeam.md
+++ b/.snippets/text/builders/get-started/endpoints/moonbeam.md
@@ -5,7 +5,6 @@
     |    Blast     |                     <pre>```https://moonbeam.public.blastapi.io```</pre>                      | 80 req/sec  |
     |   Dwellir    |                       <pre>```https://moonbeam-rpc.dwellir.com```</pre>                       | 20 req/sec  |
     |  OnFinality  |                  <pre>```https://moonbeam.api.onfinality.io/public```</pre>                   | 40 req/sec  |
-    | POKT Network | <pre>```https://moonbeam-mainnet.gateway.pokt.network/v1/lb/629a2b5650ec8c0039bb30f0```</pre> | 25 req/sec  |
     |  UnitedBloc  |                       <pre>```https://moonbeam.unitedbloc.com```</pre>                        | 32 req/sec  |
 
 

--- a/.snippets/text/builders/get-started/endpoints/moonriver.md
+++ b/.snippets/text/builders/get-started/endpoints/moonriver.md
@@ -4,7 +4,6 @@
       |    Blast     |                     <pre>```https://moonriver.public.blastapi.io```</pre>                      | 80 req/sec |
       |   Dwellir    |                       <pre>```https://moonriver-rpc.dwellir.com```</pre>                       | 20 req/sec |
       |  OnFinality  |                  <pre>```https://moonriver.api.onfinality.io/public```</pre>                   | 40 req/sec |
-      | POKT Network | <pre>```https://moonriver-mainnet.gateway.pokt.network/v1/lb/62a74fdb123e6f003963642f```</pre> | 25 req/sec |
       |  UnitedBloc  |                       <pre>```https://moonriver.unitedbloc.com```</pre>                        | 32 req/sec |
 
 === "WSS"

--- a/builders/get-started/quick-start.md
+++ b/builders/get-started/quick-start.md
@@ -34,7 +34,7 @@ When working with developer tools, depending on the tool, you might need to conf
     |    Variable     |                                                                        Value                                                                        |
     |:---------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------:|
     |    Chain ID     |                                                  <pre>```{{ networks.moonbeam.chain_id }}```</pre>                                                  |
-    | Public RPC URLs | <pre>```https://moonbeam.public.blastapi.io```</pre>  <pre>```https://moonbeam-mainnet.gateway.pokt.network/v1/lb/629a2b5650ec8c0039bb30f0```</pre> |
+    | Public RPC URLs | <pre>```https://moonbeam.public.blastapi.io```</pre>  <pre>```https://moonbeam.unitedbloc.com```</pre> |
     | Public WSS URLs |                                                 <pre>```wss://moonbeam.public.blastapi.io```</pre>                                                  |
 
 === "Moonriver"
@@ -42,7 +42,7 @@ When working with developer tools, depending on the tool, you might need to conf
     |    Variable     |                                                                         Value                                                                         |
     |:---------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------:|
     |    Chain ID     |                                                  <pre>```{{ networks.moonriver.chain_id }}```</pre>                                                   |
-    | Public RPC URLs | <pre>```https://moonriver.public.blastapi.io```</pre>  <pre>```https://moonriver-mainnet.gateway.pokt.network/v1/lb/62a74fdb123e6f003963642f```</pre> |
+    | Public RPC URLs | <pre>```https://moonriver.public.blastapi.io```</pre>  <pre>```https://moonriver.unitedbloc.com```</pre> |
     | Public WSS URLs |                                                  <pre>```wss://moonriver.public.blastapi.io```</pre>                                                  |
 
 === "Moonbase Alpha"


### PR DESCRIPTION
### Description

Remove POKT network's public RPC URL since it is no longer supported. It is still listed as an [endpoint provider](https://docs.moonbeam.network/builders/get-started/endpoints/) though.

### Checklist

- [✔] I have added a label to this PR 🏷️
- [✔] I have run my changes through Grammarly
- [✔] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [✔] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [✔] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [✔] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [✔] If images have been added, I have run the `compress-images.py` script to compress the images.
- [✔] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [✔] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [✔] Will need to create PR in `moonbeam-docs` repo to remove images
- [✔] Will need to create PR in `moonbeam-docs` repo to remove variables
- [✔] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [✔] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
