### PR TITLE
Update Subsquid to SQD Naming

### DIFF
--- a/builders/integrations/indexers/.pages
+++ b/builders/integrations/indexers/.pages
@@ -5,4 +5,4 @@ nav:
   - 'The Graph': 'thegraph.md'
   - 'Covalent API': 'covalent.md'
   - 'SubQuery': 'subquery.md'
-  - 'Subsquid': 'subsquid.md'
+  - 'SQD': 'subsquid.md'

--- a/builders/integrations/indexers/subsquid.md
+++ b/builders/integrations/indexers/subsquid.md
@@ -1,5 +1,5 @@
 ---
-title: Index Moonbeam Data with SQD (Subsquid)
+title: Index Data with SQD (formerly Subsquid)
 description: Learn how to use SQD (Subsquid), a query node framework for Substrate-based chains, to index and process Substrate and EVM data for Moonbeam and Moonriver.
 ---
 

--- a/builders/integrations/indexers/subsquid.md
+++ b/builders/integrations/indexers/subsquid.md
@@ -1,6 +1,6 @@
 ---
-title: Index Moonbeam Data with SQD (formerly Subsquid)
-description: Learn how to use SQD (formerly Subsquid), a query node framework for Substrate-based chains, to index and process Substrate and EVM data for Moonbeam and Moonriver.
+title: Index Moonbeam Data with SQD (Subsquid)
+description: Learn how to use SQD (Subsquid), a query node framework for Substrate-based chains, to index and process Substrate and EVM data for Moonbeam and Moonriver.
 ---
 
 # Indexing Moonbeam with SQD (formerly Subsquid)

--- a/builders/integrations/indexers/subsquid.md
+++ b/builders/integrations/indexers/subsquid.md
@@ -1,23 +1,23 @@
 ---
-title: Index Moonbeam Data with Subsquid
-description: Learn how to use Subsquid, a query node framework for Substrate-based chains, to index and process Substrate and EVM data for Moonbeam and Moonriver.
+title: Index Moonbeam Data with SQD (formerly Subsquid)
+description: Learn how to use SQD (formerly Subsquid), a query node framework for Substrate-based chains, to index and process Substrate and EVM data for Moonbeam and Moonriver.
 ---
 
-# Indexing Moonbeam with Subsquid
+# Indexing Moonbeam with SQD (formerly Subsquid)
 
 ## Introduction {: #introduction }
 
-[Subsquid](https://subsquid.io){target=\_blank} is a data network that allows rapid and cost-efficient retrieval of blockchain data from 100+ chains using Subsquid’s decentralized data lake and open-source SDK. In very simple terms, Subsquid can be thought of as an ETL (extract, transform, and load) tool with a GraphQL server included. It enables comprehensive filtering, pagination, and even full-text search capabilities.
+[SQD (formerly Subsquid)](https://subsquid.io){target=\_blank} is a data network that allows rapid and cost-efficient retrieval of blockchain data from 100+ chains using SQD’s decentralized data lake and open-source SDK. In very simple terms, SQD can be thought of as an ETL (extract, transform, and load) tool with a GraphQL server included. It enables comprehensive filtering, pagination, and even full-text search capabilities.
 
-Subsquid has native and full support for both Ethereum Virtual Machine (EVM) and Substrate data. Since Moonbeam is a Substrate-based smart contact platform that is EVM-compatible, Subsquid can be used to index both EVM and Substrate-based data. Subsquid offers a Substrate Archive and Processor and an EVM Archive and Processor. The Substrate Archive and Processor can be used to index both Substrate and EVM data. This allows developers to extract on-chain data from any of the Moonbeam networks and process EVM logs as well as Substrate entities (events, extrinsics, and storage items) in one single project and serve the resulting data with one single GraphQL endpoint. If you exclusively want to index EVM data, it is recommended to use the EVM Archive and Processor.
+SQD has native and full support for both Ethereum Virtual Machine (EVM) and Substrate data. Since Moonbeam is a Substrate-based smart contact platform that is EVM-compatible, SQD can be used to index both EVM and Substrate-based data. SQD offers a Substrate Archive and Processor and an EVM Archive and Processor. The Substrate Archive and Processor can be used to index both Substrate and EVM data. This allows developers to extract on-chain data from any of the Moonbeam networks and process EVM logs as well as Substrate entities (events, extrinsics, and storage items) in one single project and serve the resulting data with one single GraphQL endpoint. If you exclusively want to index EVM data, it is recommended to use the EVM Archive and Processor.
 
-This quick-start guide will show you how to create Substrate and EVM projects with Subsquid and configure it to index data on Moonbeam. For a more comprehensive end-to-end tutorial, be sure to check out [Index a Local Moonbeam Development Node with Subsquid](/tutorials/integrations/local-subsquid/){target=\_blank}.
+This quick-start guide will show you how to create Substrate and EVM projects with SQD and configure it to index data on Moonbeam. For a more comprehensive end-to-end tutorial, be sure to check out [Index a Local Moonbeam Development Node with SQD](/tutorials/integrations/local-subsquid/){target=\_blank}.
 
 --8<-- 'text/_disclaimers/third-party-content-intro.md'
 
 ## Checking Prerequisites {: #checking-prerequisites }
 
-To get started with Subsquid, you'll need to have the following:
+To get started with SQD, you'll need to have the following:
 
 - [Node.js](https://nodejs.org/en/download/package-manager){target=\_blank} version 16 or newer
 - [Docker](https://docs.docker.com/get-docker){target=\_blank}
@@ -28,15 +28,15 @@ To get started with Subsquid, you'll need to have the following:
 
 ## Index Substrate Data on Moonbeam {: #index-substrate-calls-events }
 
-To get started indexing Substrate data on Moonbeam, you'll need to create a Subsquid project and configure it for Moonbeam by taking the following steps:
+To get started indexing Substrate data on Moonbeam, you'll need to create a SQD project and configure it for Moonbeam by taking the following steps:
 
-1. Create a Subsquid project based on the Substrate template by running:
+1. Create a SQD project based on the Substrate template by running:
 
     ```bash
     sqd init INSERT_SQUID_NAME --template substrate
     ```
 
-    For more information on getting started with this template, please check out the [Quickstart: Substrate chains](https://docs.subsquid.io/quickstart/quickstart-substrate){target=\_blank} guide on Subsquid's documentation site.
+    For more information on getting started with this template, please check out the [Quickstart: Substrate chains](https://docs.subsquid.io/quickstart/quickstart-substrate){target=\_blank} guide on SQD's documentation site.
 
 2. Navigate into the root directory of your Squid project and install dependencies by running:  
 
@@ -44,7 +44,7 @@ To get started indexing Substrate data on Moonbeam, you'll need to create a Subs
     npm ci
     ```
 
-3. To configure your Subsquid project to run on Moonbeam, you'll need to update the `typegen.json` file. The `typegen.json` file is responsible for generating TypeScript interface classes for your data. Depending on the network you're indexing data on, the `specVersions` value in the `typegen.json` file should be configured as follows:
+3. To configure your SQD project to run on Moonbeam, you'll need to update the `typegen.json` file. The `typegen.json` file is responsible for generating TypeScript interface classes for your data. Depending on the network you're indexing data on, the `specVersions` value in the `typegen.json` file should be configured as follows:
 
     === "Moonbeam"
 
@@ -102,7 +102,7 @@ To get started indexing Substrate data on Moonbeam, you'll need to create a Subs
     !!! note
         --8<-- 'text/_common/endpoint-setup.md'
 
-5. There's one more quick change to make to the template. The Subsquid Substrate template is configured to process Substrate account types, but Moonbeam uses Ethereum-style accounts. The `getTransferEvents` function in the `src/main.ts` file will iterate through the events ingested by `processor.ts` and store the relevant `transfer` events in the database. In the `getTransferEvents` function, remove the ss58 encoding of the `from` and `to` fields. In an unmodified Substrate template, the `from` and `to` fields are ss58 encoded as shown:
+5. There's one more quick change to make to the template. The SQD Substrate template is configured to process Substrate account types, but Moonbeam uses Ethereum-style accounts. The `getTransferEvents` function in the `src/main.ts` file will iterate through the events ingested by `processor.ts` and store the relevant `transfer` events in the database. In the `getTransferEvents` function, remove the ss58 encoding of the `from` and `to` fields. In an unmodified Substrate template, the `from` and `to` fields are ss58 encoded as shown:
 
     ```ts
     from: ss58.codec('kusama').encode(rec.from),
@@ -116,13 +116,13 @@ To get started indexing Substrate data on Moonbeam, you'll need to create a Subs
     to: rec.to, 
     ```
 
-And that's all you have to do to configure your Subsquid project to index Substrate data on Moonbeam! Now you can update the `schema.graphql`, `typegen.json`, `src/main.ts`, and `src/processor.ts` files to index the data you need for your project! Next, take the steps in the [Run your Indexer](#run-your-indexer) section to run your indexer and query your Squid.
+And that's all you have to do to configure your SQD project to index Substrate data on Moonbeam! Now you can update the `schema.graphql`, `typegen.json`, `src/main.ts`, and `src/processor.ts` files to index the data you need for your project! Next, take the steps in the [Run your Indexer](#run-your-indexer) section to run your indexer and query your Squid.
 
 ## Index Ethereum Data on Moonbeam {: #index-ethereum-contracts }
 
-To get started indexing EVM data on Moonbeam, you'll need to create a Subsquid project and configure it for Moonbeam by taking the following steps:
+To get started indexing EVM data on Moonbeam, you'll need to create a SQD project and configure it for Moonbeam by taking the following steps:
 
-1. You can create a Subsquid project for EVM data by using the generic [EVM template](https://github.com/subsquid-labs/squid-evm-template){target=\_blank} or you can use the [ABI template](https://github.com/subsquid-labs/squid-abi-template){target=\_blank} for indexing data related to a specific contract:
+1. You can create a SQD project for EVM data by using the generic [EVM template](https://github.com/subsquid-labs/squid-evm-template){target=\_blank} or you can use the [ABI template](https://github.com/subsquid-labs/squid-abi-template){target=\_blank} for indexing data related to a specific contract:
 
     === "EVM"
 
@@ -136,7 +136,7 @@ To get started indexing EVM data on Moonbeam, you'll need to create a Subsquid p
         sqd init INSERT_SQUID_NAME --template abi
         ```
 
-    For more information on getting started with both of these templates, please check out the following Subsquid docs:
+    For more information on getting started with both of these templates, please check out the following SQD docs:
       
       - [Quickstart: EVM chains](https://docs.subsquid.io/quickstart/quickstart-ethereum){target=\_blank}
       - [Quickstart: generate from ABI](https://docs.subsquid.io/quickstart/quickstart-abi){target=\_blank}
@@ -185,11 +185,11 @@ To get started indexing EVM data on Moonbeam, you'll need to create a Subsquid p
     !!! note
         --8<-- 'text/_common/endpoint-setup.md'
 
-And that's all you have to do to configure your Subsquid project to index EVM data on Moonbeam! Now you can update the `schema.graphql`, `src/main.ts`, and `src/processor.ts` files to index the data you need for your project! Continue with the steps in the following section to run your indexer and query your Squid.
+And that's all you have to do to configure your SQD project to index EVM data on Moonbeam! Now you can update the `schema.graphql`, `src/main.ts`, and `src/processor.ts` files to index the data you need for your project! Continue with the steps in the following section to run your indexer and query your Squid.
 
 ## Run Your Indexer {: #run-your-indexer }
 
-These steps apply to both Substrate and EVM indexers. Running your Subsquid indexer after you've properly configured it takes only a few steps:  
+These steps apply to both Substrate and EVM indexers. Running your SQD indexer after you've properly configured it takes only a few steps:  
 
 1. Launch Postgres by running:
 
@@ -235,6 +235,6 @@ These steps apply to both Substrate and EVM indexers. Running your Subsquid inde
         }
         ```
 
-If you're interested in a step-by-step tutorial to get started indexing data on Moonbeam, you can check out the [Index NFT Token Transfers on Moonbeam with Subsquid](/tutorials/integrations/nft-subsquid/){target=\_blank} tutorial!
+If you're interested in a step-by-step tutorial to get started indexing data on Moonbeam, you can check out the [Index NFT Token Transfers on Moonbeam with SQD](/tutorials/integrations/nft-subsquid/){target=\_blank} tutorial!
 
 --8<-- 'text/_disclaimers/third-party-content.md'

--- a/tutorials/integrations/.pages
+++ b/tutorials/integrations/.pages
@@ -4,8 +4,8 @@ nav:
   - index.md
   - 'Use Indexers to Query Chain Data':
     - 'indexers.index.md'
-    - '[Subsquid] Index a Local Dev Node': 'local-subsquid.md'
-    - '[Subsquid] Index NFT Transfers': 'nft-subsquid.md'
+    - '[SQD] Index a Local Dev Node': 'local-subsquid.md'
+    - '[SQD] Index NFT Transfers': 'nft-subsquid.md'
   - 'Use Oracles to Fetch Off-Chain Data':
     - 'oracles.index.md'
     - '[Supra] Fetch Price Data': 'supra.md'

--- a/tutorials/integrations/local-subsquid.md
+++ b/tutorials/integrations/local-subsquid.md
@@ -1,9 +1,9 @@
 ---
 title: Index a Local Development Node
-description: Improve your DApp development experience by following this guide to learn how to index a DApp deployed locally on a Moonbeam development node with Subsquid!
+description: Improve your DApp development experience by following this guide to learn how to index a DApp deployed locally on a Moonbeam dev node with SQD (formerly Subsquid)!
 ---
 
-# Index a Local Moonbeam Development Node with Subsquid
+# Index a Local Moonbeam Development Node with SQD (formerly Subsquid)
 
 _by Erin Shaben and Kevin Neilson_
 
@@ -11,9 +11,9 @@ _by Erin Shaben and Kevin Neilson_
 
 When developing a dApp, it's beneficial to develop smart contracts using a local development environment as opposed to a live network, such as a TestNet or MainNet. Local development removes some of the hassles involved with developing on a live network, like having to fund development accounts and waiting for blocks to be produced. On Moonbeam, developers can spin up their own local [Moonbeam development node](/builders/get-started/networks/moonbeam-dev/){target=\_blank} to quickly and easily build and test applications.
 
-But what about dApps that rely on indexers to index blockchain data? How can developers of these applications streamline the development process? Thanks to [Subsquid](/builders/integrations/indexers/subsquid/){target=\_blank}, a data network for retrieving data from 100+ chains, it is now possible to index blocks in a local development environment, such as your Moonbeam development node!
+But what about dApps that rely on indexers to index blockchain data? How can developers of these applications streamline the development process? Thanks to [SQD](/builders/integrations/indexers/subsquid/){target=\_blank}, a data network for retrieving data from 100+ chains, it is now possible to index blocks in a local development environment, such as your Moonbeam development node!
 
-This tutorial will walk you through the process of indexing data on a local Moonbeam development node using Subsquid. We'll create an ERC-20 contract and use Subsquid to index transfers of our ERC-20.
+This tutorial will walk you through the process of indexing data on a local Moonbeam development node using SQD. We'll create an ERC-20 contract and use SQD to index transfers of our ERC-20.
 
 ## Check Prerequisites {: #check-prerequisites }
 
@@ -24,7 +24,7 @@ To follow along with this tutorial, you'll need to have:
 - An empty Hardhat project. For step-by-step instructions, please refer to the [Creating a Hardhat Project](/builders/ethereum/dev-env/hardhat/#creating-a-hardhat-project){target=\_blank} section of our Hardhat documentation page
 - An [ERC-20 token deployed](#deploy-an-erc-20-contract) to your local development node, unless you plan on indexing Moonbase Alpha and using an existing ERC-20
 
-We'll configure our Hardhat project and create our Subsquid project later on in the tutorial.
+We'll configure our Hardhat project and create our SQD project later on in the tutorial.
 
 ## Spin up a Local Development Node {: #spin-up-a-local-development-node }
 
@@ -200,9 +200,9 @@ As each transaction is sent, you'll see a log printed to the terminal.
 
 Now we can move on to creating our Squid to index the data on our local development node.
 
-## Create a Subsquid Project {: #create-subsquid-project }
+## Create a SQD Project {: #create-SQD-project }
 
-Now we're going to create our Subquid project. First, we'll need to install the [Subsquid CLI](https://docs.subsquid.io/squid-cli){target=\_blank}:
+Now we're going to create our Subquid project. First, we'll need to install the [SQD CLI](https://docs.subsquid.io/squid-cli){target=\_blank}:
 
 ```bash
 npm i -g @subsquid/cli@latest
@@ -273,7 +273,7 @@ This will generate the related TypeScript interface classes in the `src/abi/erc2
 
 ### Configure the Processor {: #configure-the-processor}
 
-The `processor.ts` file tells Subsquid exactly what data you'd like to ingest. Transforming that data into the exact desired format will take place at a later step. In `processor.ts`, we'll need to indicate a data source, a contract address, the event(s) to index, and a block range.
+The `processor.ts` file tells SQD exactly what data you'd like to ingest. Transforming that data into the exact desired format will take place at a later step. In `processor.ts`, we'll need to indicate a data source, a contract address, the event(s) to index, and a block range.
 
 Open up the `src` folder and head to the `processor.ts` file.
 
@@ -283,13 +283,13 @@ To get started, you can import the ERC-20 ABI, which will be used to define the 
 import * as erc20 from './abi/erc20';
 ```
 
-Next, we need to tell the Subsquid processor which contract we're interested in. Create a constant for the address in the following manner:
+Next, we need to tell the SQD processor which contract we're interested in. Create a constant for the address in the following manner:
 
 ```ts
 export const contractAddress = 'INSERT_CONTRACT_ADDRESS'.toLowerCase();
 ```
 
-The `.toLowerCase()` is critical because the Subsquid processor is case-sensitive, and some block explorers format contract addresses with capitalization. Next, you'll see the line `export const processor = new EvmBatchProcessor()`, followed by `.setDataSource`. We'll need to make a few changes here. Subsquid has [available archives for many chains, including Moonbeam, Moonriver, and Moonbase Alpha](https://docs.subsquid.io/evm-indexing/supported-networks){target=\_blank} that can speed up the data retrieval process. For indexing a local development node, there's no archive necessary so the exclusive data source will be the RPC URL of our local node. Go ahead and comment out or delete the archive line. Once done, your code should look similar to the below:
+The `.toLowerCase()` is critical because the SQD processor is case-sensitive, and some block explorers format contract addresses with capitalization. Next, you'll see the line `export const processor = new EvmBatchProcessor()`, followed by `.setDataSource`. We'll need to make a few changes here. SQD has [available archives for many chains, including Moonbeam, Moonriver, and Moonbase Alpha](https://docs.subsquid.io/evm-indexing/supported-networks){target=\_blank} that can speed up the data retrieval process. For indexing a local development node, there's no archive necessary so the exclusive data source will be the RPC URL of our local node. Go ahead and comment out or delete the archive line. Once done, your code should look similar to the below:
 
 ```ts
 .setDataSource({
@@ -300,7 +300,7 @@ The `.toLowerCase()` is critical because the Subsquid processor is case-sensitiv
 })
 ```
 
-![Run Subsquid commands](/images/tutorials/integrations/local-subsquid/new/local-squid-6.webp)
+![Run SQD commands](/images/tutorials/integrations/local-subsquid/new/local-squid-6.webp)
 
 The Squid template comes with a variable for your RPC URL defined in your `.env` file. You can replace that with the RPC URL for your local development node. For demonstration purposes, the RPC URL for a local development node is hardcoded directly, as shown above. If you're setting the RPC URL in your `.env`, the respective line will look like this:
 
@@ -354,7 +354,7 @@ Once you've completed the prior steps, your `processor.ts` file should look simi
 
 ### Transform and Save the Data {: #transform-and-save-the-data}
 
-While `processor.ts` determines the data being consumed, `main.ts` determines the bulk of actions related to processing and transforming that data. In the simplest terms, we are processing the data that was ingested via the Subsquid processor and inserting the desired pieces into a TypeORM database. For more detailed information on how Subsquid works, be sure to check out the [Subsquid docs on Developing a Squid](https://docs.subsquid.io/basics/squid-development){target=\_blank}
+While `processor.ts` determines the data being consumed, `main.ts` determines the bulk of actions related to processing and transforming that data. In the simplest terms, we are processing the data that was ingested via the SQD processor and inserting the desired pieces into a TypeORM database. For more detailed information on how SQD works, be sure to check out the [SQD docs on Developing a Squid](https://docs.subsquid.io/basics/squid-development){target=\_blank}
 
 Our `main.ts` file is going to scan through each processed block for the `Transfer` event and decode the transfer details, including the sender, receiver, and amount. The script also fetches account details for involved addresses and creates transfer objects with the extracted data. The script then inserts these records into a TypeORM database enabling them to be easily queried.
 
@@ -454,7 +454,7 @@ And that's it! You can now run queries against your Squid on the GraphQL playgro
 
 All of the transfers will be returned, including the transfer of the initial supply to Alith's account and the transfers from Alith to Baltathar, Charleth, Dorothy, and Ethan.
 
-And that's it! You've successfully used Subsquid to index data on a local Moonbeam development node! You can view the entire project on [GitHub](https://github.com/eshaben/local-squid-demo){target=\_blank}.
+And that's it! You've successfully used SQD to index data on a local Moonbeam development node! You can view the entire project on [GitHub](https://github.com/eshaben/local-squid-demo){target=\_blank}.
 
 ## Debug Your Squid {: #debug-your-squid }
 
@@ -473,7 +473,7 @@ You can also add logging statements directly to your `main.ts` file to indicate 
     --8<-- 'code/tutorials/integrations/local-subsquid/main-with-logging.ts'
     ```
 
-See the [Subsquid guide to logging](https://docs.subsquid.io/basics/logging){target=\_blank} for more information on debug mode.
+See the [SQD guide to logging](https://docs.subsquid.io/basics/logging){target=\_blank} for more information on debug mode.
 
 ### Common Errors {: #common-errors }
 
@@ -489,7 +489,7 @@ This error indicates that your indexer is trying to process blocks that don't ex
 .setBlockRange({from: 0, to: 100})
 ```
 
-Another common error can occur when you're experimenting with multiple instances of Subsquid on your machine.
+Another common error can occur when you're experimenting with multiple instances of SQD on your machine.
 
 ```text
 Error response from daemon: driver failed programming external connectivity on endpoint my-awesome-squid-db-1
@@ -497,7 +497,7 @@ Error response from daemon: driver failed programming external connectivity on e
 Bind for 0.0.0.0:23798 failed: port is already allocated
 ```
 
-This error indicates that you have another instance of Subsquid running somewhere else. You can stop that gracefully with the command `sqd down` or by pressing the **Stop** button next to the container in Docker Desktop.
+This error indicates that you have another instance of SQD running somewhere else. You can stop that gracefully with the command `sqd down` or by pressing the **Stop** button next to the container in Docker Desktop.
 
 ```text
 Error: connect ECONNREFUSED 127.0.0.1:23798

--- a/tutorials/integrations/local-subsquid.md
+++ b/tutorials/integrations/local-subsquid.md
@@ -1,6 +1,6 @@
 ---
 title: Index a Local Development Node
-description: Improve your DApp development experience by following this guide to learn how to index a DApp deployed locally on a Moonbeam dev node with SQD (formerly Subsquid)!
+description: Improve your DApp development experience by following this guide to learn how to index a DApp deployed locally on a Moonbeam dev node with SQD (Subsquid)!
 ---
 
 # Index a Local Moonbeam Development Node with SQD (formerly Subsquid)

--- a/tutorials/integrations/nft-subsquid.md
+++ b/tutorials/integrations/nft-subsquid.md
@@ -219,7 +219,7 @@ Have fun playing around with queries; after all, it's a _playground_!
 
 SQD offers a SaaS solution to host projects created by its community. All templates ship with a deployment manifest file named `squid.yml`, which can be used with the Squid CLI command `sqd deploy`.
 
-Please refer to the [SQD Cloud Quickstart](https://docs.subsquid.io/cloud/overview/){target=\_blank} page on Subquid's documentation site for more information.
+Please refer to the [SQD Cloud Quickstart](https://docs.subsquid.io/cloud/overview/){target=\_blank} page on SQD's documentation site for more information.
 
 ## Example Project Repository {: #example-project-repository }
 

--- a/tutorials/integrations/nft-subsquid.md
+++ b/tutorials/integrations/nft-subsquid.md
@@ -1,5 +1,5 @@
 ---
-title: Index NFT Transfers with SQD (formerly Subsquid)
+title: Index NFT Transfers with SQD (Subsquid)
 description: Learn how to use SQD (formerly Subsquid), a query node framework for Substrate-based chains, to index and process NFT transfer data for Moonbeam and Moonriver.
 ---
 

--- a/tutorials/integrations/nft-subsquid.md
+++ b/tutorials/integrations/nft-subsquid.md
@@ -9,13 +9,13 @@ _by Massimo Luraschi_
 
 ## Introduction {: #introduction }
 
-[SQD (formerly Subsquid)](https://subsquid.io){target=\_blank} is a data network that allows rapid and cost-efficient retrieval of blockchain data from 100+ chains using Subsquid's decentralized data lake and open-source SDK.
+[SQD (formerly Subsquid)](https://subsquid.io){target=\_blank} is a data network that allows rapid and cost-efficient retrieval of blockchain data from 100+ chains using SQD's decentralized data lake and open-source SDK.
 
 The SDK offers a highly customizable Extract-Transform-Load-Query stack and indexing speeds of up to and beyond 50,000 blocks per second when indexing events and transactions.
 
-Subsquid has native and full support for the Ethereum Virtual Machine (EVM) and Substrate data. This allows developers to extract on-chain data from any of the Moonbeam networks, process EVM logs and Substrate entities (events, extrinsic, and storage items) in one single project, and serve the resulting data with one single GraphQL endpoint. With Subsquid, filtering by EVM topic, contract address, and block range are all possible.
+SQD has native and full support for the Ethereum Virtual Machine (EVM) and Substrate data. This allows developers to extract on-chain data from any of the Moonbeam networks, process EVM logs and Substrate entities (events, extrinsic, and storage items) in one single project, and serve the resulting data with one single GraphQL endpoint. With SQD, filtering by EVM topic, contract address, and block range are all possible.
 
-This guide will explain how to create a Subsquid project (also known as a _"Squid"_) from a template (indexing Moonsama transfers on Moonriver) and change it to index ERC-721 token transfers on the Moonbeam network. As such, you'll be looking at the `Transfer` EVM event topics. This guide can be adapted for Moonbase Alpha as well.
+This guide will explain how to create a SQD project (also known as a _"Squid"_) from a template (indexing Moonsama transfers on Moonriver) and change it to index ERC-721 token transfers on the Moonbeam network. As such, you'll be looking at the `Transfer` EVM event topics. This guide can be adapted for Moonbase Alpha as well.
 
 --8<-- 'text/_disclaimers/third-party-content-intro.md'
 
@@ -68,7 +68,7 @@ The generated entity classes can then be browsed in the `src/model/generated` di
 
 ## ABI Definition and Type Generation {: #abi-definition }
 
-Subsquid maintains [tools](https://docs.subsquid.io/sdk/resources/tools/typegen/generation/?typegen=substrate){target=\_blank} for the automated generation of TypeScript classes to handle Substrate data sources (events, extrinsics, storage items). Possible runtime upgrades are automatically detected and accounted for.
+SQD maintains [tools](https://docs.subsquid.io/sdk/resources/tools/typegen/generation/?typegen=substrate){target=\_blank} for the automated generation of TypeScript classes to handle Substrate data sources (events, extrinsics, storage items). Possible runtime upgrades are automatically detected and accounted for.
 
 Similar functionality is available for EVM indexing through the [`squid-evm-typegen`](https://docs.subsquid.io/sdk/resources/tools/typegen/generation/?typegen=evm){target=\_blank} tool. It generates TypeScript modules for handling EVM logs and transactions based on a [JSON ABI](https://docs.ethers.org/v6/basics/abi/){target=\_blank} of the contract.
 
@@ -84,7 +84,7 @@ The results will be stored at `src/abi`. One module will be generated for each A
 
 ## Processor Object and the Batch Handler {: #define-event-handlers }
 
-Subsquid SDK provides users with the [`SubstrateBatchProcessor` class](https://docs.subsquid.io/sdk/reference/processors/substrate-batch/context-interfaces/){target=\_blank}. The `SubstrateBatchProcessor` declaration and configurations are in the `src/processor.ts` file. Its instances connect to [Subsquid Network gateways](https://docs.subsquid.io/subsquid-network/reference/substrate-networks/){target=\_blank} at chain-specific URLs to get chain data and apply custom transformations. The indexing begins at the starting block and keeps up with new blocks after reaching the tip.
+SQD SDK provides users with the [`SubstrateBatchProcessor` class](https://docs.subsquid.io/sdk/reference/processors/substrate-batch/context-interfaces/){target=\_blank}. The `SubstrateBatchProcessor` declaration and configurations are in the `src/processor.ts` file. Its instances connect to [SQD Network gateways](https://docs.subsquid.io/subsquid-network/reference/substrate-networks/){target=\_blank} at chain-specific URLs to get chain data and apply custom transformations. The indexing begins at the starting block and keeps up with new blocks after reaching the tip.
 
 The `SubstrateBatchProcessor` [exposes methods](https://docs.subsquid.io/sdk/reference/processors/substrate-batch/general/){target=\_blank} to "subscribe" to specific data such as Substrate events, extrinsics, storage items, or, for EVM, logs, and transactions. The actual data processing is then started by calling the `.run()` function, as seen in the `src/main.ts` file. This will start generating requests to the gateway for [_batches_](https://docs.subsquid.io/sdk/resources/basics/batch-processing/){target=\_blank} of data specified in the configuration and will trigger the callback function every time a batch is returned by the gateway.
 
@@ -107,7 +107,7 @@ Now, let's take a look at the complete contents of the file:
 
 In the `src/processor.ts` file, Squids instantiate the processor (a `SubstrateBatchProcessor` in our case) and configure it.
 
-We adapt the template code to process EVM logs for the two Exiled Racers contracts and point the processor data source setting to the Moonbeam Subsquid Network gateway URL. Here is the result:
+We adapt the template code to process EVM logs for the two Exiled Racers contracts and point the processor data source setting to the Moonbeam SQD Network gateway URL. Here is the result:
 
 ```typescript title="src/processor.ts"
 --8<-- 'code/tutorials/integrations/nft-subsquid/processor.ts'
@@ -122,7 +122,7 @@ If you are adapting this guide for Moonbase Alpha, be sure to update the data so
 !!! note
     This code expects to find a working Moonbeam RPC URL in the `RPC_ENDPOINT` environment variable. You can get your own endpoint and API key from a supported [Endpoint Provider](/builders/get-started/endpoints/){target=\_blank}.
 
-    Set it in the `.env` file and [Subsquid Cloud secrets](https://docs.subsquid.io/cloud/resources/env-variables/){target=\_blank} if and when you deploy your Squid there. We tested the code using a public endpoint at `wss://wss.api.moonbeam.network`; we recommend using private endpoints for production.
+    Set it in the `.env` file and [SQD Cloud secrets](https://docs.subsquid.io/cloud/resources/env-variables/){target=\_blank} if and when you deploy your Squid there. We tested the code using a public endpoint at `wss://wss.api.moonbeam.network`; we recommend using private endpoints for production.
 
 ## Define the Batch Handler {: #define-batch-handler }
 
@@ -135,7 +135,7 @@ Here is the result:
 ```
 
 !!! note
-    The `contract.tokenURI` call accesses the **state** of the contract via a chain RPC endpoint. This can slow down indexing, but this data is only available in this way. You'll find more information on accessing state in the [dedicated section of the Subsquid docs](https://docs.subsquid.io/sdk/resources/tools/typegen/state-queries/#example-1){target=\_blank}.
+    The `contract.tokenURI` call accesses the **state** of the contract via a chain RPC endpoint. This can slow down indexing, but this data is only available in this way. You'll find more information on accessing state in the [dedicated section of the SQD docs](https://docs.subsquid.io/sdk/resources/tools/typegen/state-queries/#example-1){target=\_blank}.
 
 ## Launch and Set Up the Database {: #launch-database }
 
@@ -217,15 +217,15 @@ Have fun playing around with queries; after all, it's a _playground_!
 
 ## Publish the Project {: #publish-the-project }
 
-Subsquid offers a SaaS solution to host projects created by its community. All templates ship with a deployment manifest file named `squid.yml`, which can be used with the Squid CLI command `sqd deploy`.
+SQD offers a SaaS solution to host projects created by its community. All templates ship with a deployment manifest file named `squid.yml`, which can be used with the Squid CLI command `sqd deploy`.
 
-Please refer to the [Subsquid Cloud Quickstart](https://docs.subsquid.io/cloud/overview/){target=\_blank} page on Subquid's documentation site for more information.
+Please refer to the [SQD Cloud Quickstart](https://docs.subsquid.io/cloud/overview/){target=\_blank} page on Subquid's documentation site for more information.
 
 ## Example Project Repository {: #example-project-repository }
 
-You can view the template used here and many other example repositories [on Subsquid's examples organization on GitHub](https://github.com/orgs/subsquid-labs/repositories){target=\_blank}.
+You can view the template used here and many other example repositories [on SQD's examples organization on GitHub](https://github.com/orgs/subsquid-labs/repositories){target=\_blank}.
 
-[Subsquid's documentation](https://docs.subsquid.io){target=\_blank} contains informative material, and it's the best place to start if you are curious about some aspects that were not fully explained in this guide.
+[SQD's documentation](https://docs.subsquid.io){target=\_blank} contains informative material, and it's the best place to start if you are curious about some aspects that were not fully explained in this guide.
 
 --8<-- 'text/_disclaimers/educational-tutorial.md'
 

--- a/tutorials/integrations/nft-subsquid.md
+++ b/tutorials/integrations/nft-subsquid.md
@@ -1,15 +1,15 @@
 ---
-title: Index NFT Transfers with Subsquid
-description: Learn how to use Subsquid, a query node framework for Substrate-based chains, to index and process NFT transfer data for Moonbeam and Moonriver.
+title: Index NFT Transfers with SQD (formerly Subsquid)
+description: Learn how to use SQD (formerly Subsquid), a query node framework for Substrate-based chains, to index and process NFT transfer data for Moonbeam and Moonriver.
 ---
 
-# Indexing NFT Transfers on Moonbeam with Subsquid
+# Indexing NFT Transfers on Moonbeam with SQD (formerly Subsquid)
 
 _by Massimo Luraschi_
 
 ## Introduction {: #introduction }
 
-[Subsquid](https://subsquid.io){target=\_blank} is a data network that allows rapid and cost-efficient retrieval of blockchain data from 100+ chains using Subsquid's decentralized data lake and open-source SDK.
+[SQD (formerly Subsquid)](https://subsquid.io){target=\_blank} is a data network that allows rapid and cost-efficient retrieval of blockchain data from 100+ chains using Subsquid's decentralized data lake and open-source SDK.
 
 The SDK offers a highly customizable Extract-Transform-Load-Query stack and indexing speeds of up to and beyond 50,000 blocks per second when indexing events and transactions.
 


### PR DESCRIPTION
### Description

Subsquid has rebranded as SQD. This changes all names where appropriate but doesn't touch link names or anything like that. Subsquid has retained their old URL(https://subsquid.io/) and has not changed it to SQD in URLs. 

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
