### PR TITLE
Dawn/bump to client v0.39.0

### DIFF
--- a/.snippets/code/builders/ethereum/json-rpc/debug-trace/terminal/start-up-logs.md
+++ b/.snippets/code/builders/ethereum/json-rpc/debug-trace/terminal/start-up-logs.md
@@ -1,7 +1,7 @@
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --network host  \
     <br>-u $(id -u ${USER}):$(id -g ${USER}) \
-        moonbeamfoundation/moonbeam-tracing:v0.38.0-3000-latest \
+        moonbeamfoundation/moonbeam-tracing:v0.39.0-3000-latest \
     <br>--name="Moonbean-Tracing-Tutorial" \
     <br>--unsafe-rpc-external \
     <br>--ethapi=debug,trace,txpool \
@@ -12,7 +12,7 @@
   <br>
   <span data-ty>CLI parameter `--execution` has no effect anymore and will be removed in the future!
     <br> 2024-04-29 13:52:00 Moonbeam Parachain Collator
-    <br> 2024-04-29 13:52:00 ✌️  version 0.38.0-be5032c7749
+    <br> 2024-04-29 13:52:00 ✌️  version 0.39.0-be5032c7749
     <br> 2024-04-29 13:52:00 ❤️  by PureStake, 2019-2024
     <br> 2024-04-29 13:52:00 📋 Chain specification: Moonbase Development Testnet
     <br> 2024-04-29 13:52:00 🏷  Node name: Moonbean-Tracing-Tutorial

--- a/.snippets/code/builders/ethereum/json-rpc/debug-trace/terminal/start-up-logs.md
+++ b/.snippets/code/builders/ethereum/json-rpc/debug-trace/terminal/start-up-logs.md
@@ -1,7 +1,7 @@
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --network host  \
     <br>-u $(id -u ${USER}):$(id -g ${USER}) \
-        moonbeamfoundation/moonbeam-tracing:v0.39.0-3000-latest \
+        moonbeamfoundation/moonbeam-tracing:v0.39.0-3100-latest \
     <br>--name="Moonbean-Tracing-Tutorial" \
     <br>--unsafe-rpc-external \
     <br>--ethapi=debug,trace,txpool \

--- a/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-pull.md
+++ b/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-pull.md
@@ -1,7 +1,7 @@
 <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.38.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.39.0</span>
   <br>
-  <span data-ty>v0.38.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.39.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -10,7 +10,7 @@
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:1def3370159ee7d14fce3951a1198bda7c51af566e0b3d69ce4644338e29f046
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.38.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.38.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.39.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.39.0
   </span>
 </div>

--- a/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-run.md
+++ b/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-run.md
@@ -1,12 +1,12 @@
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.38.0 \
+    <br> moonbeamfoundation/moonbeam:v0.39.0 \
     <br> --dev --rpc-external
   </span>
   <br>
   <span data-ty>CLI parameter `--execution` has no effect anymore and will be removed in the future!
     <br> 2024-04-29 06:09:29 Moonbeam Parachain Collator
-    <br> 2024-04-29 06:09:29 ✌️  0.38.0-be5032c7749
+    <br> 2024-04-29 06:09:29 ✌️  0.39.0-be5032c7749
     <br> 2024-04-29 06:09:29 ❤️  by PureStake, 2019-2024
     <br> 2024-04-29 06:09:29 📋 Chain specification: Moonbase Development Testnet
     <br> 2024-04-29 06:09:29 🏷  Node name: black-and-white-sticks-9174

--- a/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/run-binary.md
+++ b/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/run-binary.md
@@ -3,7 +3,7 @@
   <br>
   <span data-ty>CLI parameter `--execution` has no effect anymore and will be removed in the future!
     <br> 2024-01-10 06:41:29 Moonbeam Parachain Collator
-    <br> 2024-01-10 06:41:29 ✌️  version 0.38.8-7131ef902c0
+    <br> 2024-01-10 06:41:29 ✌️  version 0.39.8-7131ef902c0
     <br> 2024-01-10 06:41:29 ❤️  by PureStake, 2019-2024
     <br> 2024-01-10 06:41:29 📋 Chain specification: Moonbase Development Testnet
     <br> 2024-01-10 06:41:29 🏷  Node name: black-and-white-sticks-9174

--- a/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/sidecar.md
+++ b/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/sidecar.md
@@ -1,7 +1,7 @@
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>node_modules/.bin/substrate-api-sidecar</span>
   <br>
-  <span data-ty>v0.38.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.39.0: Pulling from moonbeamfoundation/moonbeam
     <br>SAS:
         <br>📦 LOG:
         <br>    ✅ LEVEL: "info"

--- a/variables.yml
+++ b/variables.yml
@@ -17,7 +17,7 @@ networks:
     block_explorer: https://moonbase.moonscan.io/
     spec_version: runtime-3000
     parachain_release_tag: v0.39.0 # must be in this exact format for links to work
-    parachain_sha256sum: 6c2cb1e67d4fa233f5a28a4e8fd8cb40d0739e42609c9cc50601470d73623132
+    parachain_sha256sum: 7f085fb94719e49f6784ffb41c577b6f0beec7a63db907a179ef8de1ce7f66d6
     tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3001-latest
     gas_block: 60,000,000
     gas_block_numbers_only: 60000000

--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
     build_tag: v0.39.0
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3001-latest
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3100-latest
     rpc_url: http://127.0.0.1:9944
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -18,7 +18,7 @@ networks:
     spec_version: runtime-3000
     parachain_release_tag: v0.39.0 # must be in this exact format for links to work
     parachain_sha256sum: 7f085fb94719e49f6784ffb41c577b6f0beec7a63db907a179ef8de1ce7f66d6
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3001-latest
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3100-latest
     gas_block: 60,000,000
     gas_block_numbers_only: 60000000
     gas_tx: 52,000,000
@@ -430,7 +430,7 @@ networks:
     node_directory: /var/lib/moonriver-data
     parachain_release_tag: v0.39.0
     parachain_sha256sum: 6c2cb1e67d4fa233f5a28a4e8fd8cb40d0739e42609c9cc50601470d73623132
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3001-latest
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3100-latest
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     spec_version: runtime-3000
@@ -806,7 +806,7 @@ networks:
     node_directory: /var/lib/moonbeam-data
     parachain_release_tag: v0.39.0
     parachain_sha256sum: 6c2cb1e67d4fa233f5a28a4e8fd8cb40d0739e42609c9cc50601470d73623132
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3001-latest
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3100-latest
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     spec_version: runtime-3001

--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
-    build_tag: v0.38.0
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.38.0-3001-latest
+    build_tag: v0.39.0
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3001-latest
     rpc_url: http://127.0.0.1:9944
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -16,9 +16,9 @@ networks:
     chain_spec: alphanet
     block_explorer: https://moonbase.moonscan.io/
     spec_version: runtime-3000
-    parachain_release_tag: v0.38.0 # must be in this exact format for links to work
+    parachain_release_tag: v0.39.0 # must be in this exact format for links to work
     parachain_sha256sum: 6c2cb1e67d4fa233f5a28a4e8fd8cb40d0739e42609c9cc50601470d73623132
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.38.0-3001-latest
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3001-latest
     gas_block: 60,000,000
     gas_block_numbers_only: 60000000
     gas_tx: 52,000,000
@@ -428,9 +428,9 @@ networks:
     chain_id: 1285
     hex_chain_id: '0x505'
     node_directory: /var/lib/moonriver-data
-    parachain_release_tag: v0.38.0
+    parachain_release_tag: v0.39.0
     parachain_sha256sum: 6c2cb1e67d4fa233f5a28a4e8fd8cb40d0739e42609c9cc50601470d73623132
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.38.0-3001-latest
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3001-latest
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     spec_version: runtime-3000
@@ -804,9 +804,9 @@ networks:
     chain_id: 1284
     hex_chain_id: '0x504'
     node_directory: /var/lib/moonbeam-data
-    parachain_release_tag: v0.38.0
+    parachain_release_tag: v0.39.0
     parachain_sha256sum: 6c2cb1e67d4fa233f5a28a4e8fd8cb40d0739e42609c9cc50601470d73623132
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.38.0-3001-latest
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.39.0-3001-latest
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     spec_version: runtime-3001


### PR DESCRIPTION
### Description

Updates to bump client to v0.39.0
- Updates the build_tag and parachain_release_tag in the variables.yml file from v0.38.0 to v0.39.0
- Updates all other uses of the client version (snippets, etc.) to v0.39.0
- Generates the new parachain_sha256sum value in the variables.yml file

### Checklist

- [x ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
