### PR TITLE
adds moon_getLatestSyncedBlock to moonbeam custom API methods

### DIFF
--- a/builders/ethereum/json-rpc/moonbeam-custom-api.md
+++ b/builders/ethereum/json-rpc/moonbeam-custom-api.md
@@ -7,7 +7,12 @@ description: Discover Moonbeam's specialized API endpoints, featuring custom JSO
 
 ## Introduction {: #introduction }
 
-Moonbeam nodes include support for two custom JSON-RPC endpoints: `moon_isBlockFinalized` and `moon_isTxFinalized`. These endpoints provide valuable functionality for checking the finality of on-chain events.
+Moonbeam nodes include support for custom JSON-RPC endpoints: 
+- `moon_isBlockFinalized` 
+- `moon_isTxFinalized`
+- `moon_getLatestSyncedBlock`
+
+These endpoints provide valuable functionality for checking the finality of on-chain events.
 
 To begin exploring Moonbeam's custom JSON-RPC endpoints, you can try out the provided curl examples below. These examples demonstrate how to query the public RPC endpoint of Moonbase Alpha. However, you can easily modify them to use with your own Moonbeam or Moonriver endpoint by changing the URL and API key. If you haven't already, you can obtain your endpoint and API key from one of our supported [Endpoint Providers](/builders/get-started/endpoints/){target=\_blank}.
 
@@ -58,3 +63,30 @@ To begin exploring Moonbeam's custom JSON-RPC endpoints, you can try out the pro
           "params": ["INSERT_TRANSACTION_HASH"]
         }' {{ networks.moonbase.rpc_url }}
         ```
+
+???+ function "moon_getLatestSyncedBlock"
+
+    Returns the latest synced block number.
+
+    === "Parameters"
+
+        None
+
+    === "Returns"
+
+        Returns the latest synced block from Frontier's backend
+
+    === "Example"
+
+        ```bash
+        curl -H "Content-Type: application/json" -X POST --data '{
+          "jsonrpc": "2.0",
+          "id": "1",
+          "method": "moon_getLatestSyncedBlock",
+          "params": []
+        }' {{ networks.moonbase.rpc_url }}
+        ```
+
+
+
+    

--- a/builders/ethereum/json-rpc/moonbeam-custom-api.md
+++ b/builders/ethereum/json-rpc/moonbeam-custom-api.md
@@ -8,6 +8,7 @@ description: Discover Moonbeam's specialized API endpoints, featuring custom JSO
 ## Introduction {: #introduction }
 
 Moonbeam nodes include support for custom JSON-RPC endpoints: 
+
 - `moon_isBlockFinalized` 
 - `moon_isTxFinalized`
 - `moon_getLatestSyncedBlock`
@@ -74,7 +75,7 @@ To begin exploring Moonbeam's custom JSON-RPC endpoints, you can try out the pro
 
     === "Returns"
 
-        Returns the latest synced block from Frontier's backend
+        Returns an integer: the latest synced block from Frontier's backend
 
     === "Example"
 


### PR DESCRIPTION
### Description

- adds moon_getLatestSyncedBlock to moonbeam custom API methods
- includes curl example script

### Checklist

- [ x ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
