### PR TITLE
Add info on session keys for node operators

### DIFF
--- a/.snippets/text/node-operators/networks/run-a-node/systemd/run-service.md
+++ b/.snippets/text/node-operators/networks/run-a-node/systemd/run-service.md
@@ -1,4 +1,4 @@
-Almost there! Register and start the service by running:
+Register and start the service by running:
 
 ```bash
 systemctl enable moonbeam.service

--- a/node-operators/networks/run-a-node/docker.md
+++ b/node-operators/networks/run-a-node/docker.md
@@ -279,7 +279,7 @@ Beginning with v0.39.0, Moonbeam collator nodes no longer generate session keys 
 
     docker run --network="host" -v "/var/lib/moonbeam-data:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
-    moonbeamfoundation/moonbeam:v0.39.0 key generate-node-key --file /data/node-key
+     moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }} key generate-node-key --file /data/node-key
     
     ```
 
@@ -289,7 +289,7 @@ Beginning with v0.39.0, Moonbeam collator nodes no longer generate session keys 
 
     docker run --network="host" -v "/var/lib/moonriver-data:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
-    moonbeamfoundation/moonbeam:v0.39.0 key generate-node-key --file /data/node-key
+     moonbeamfoundation/moonbeam:{{ networks.moonriver.parachain_release_tag }} key generate-node-key --file /data/node-key
 
     ```
 
@@ -299,7 +299,7 @@ Beginning with v0.39.0, Moonbeam collator nodes no longer generate session keys 
 
     docker run --network="host" -v "/var/lib/alphanet-data:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
-    moonbeamfoundation/moonbeam:v0.39.0 key generate-node-key --file /data/node-key
+     moonbeamfoundation/moonbeam:{{ networks.moonbase.parachain_release_tag }} key generate-node-key --file /data/node-key
 
     ```
 

--- a/node-operators/networks/run-a-node/docker.md
+++ b/node-operators/networks/run-a-node/docker.md
@@ -271,7 +271,9 @@ For an overview of the flags used in the following start-up commands, plus addit
 
 ### Collator Node
 
-Beginning with v0.39.0, Moonbeam collator nodes no longer generate session keys automatically on start-up. Run the following command to generate and store on disk the session keys that will be referenced in the start-up command: 
+Beginning with v0.39.0, new Moonbeam collator nodes will no longer generate session keys automatically on start-up. Nodes in existence prior to v0.39.0 do not need to make changes to how they handle session keys. 
+
+When setting up a new node, run the following command to generate and store on disk the session keys that will be referenced in the start-up command: 
 
 === "Moonbeam"
 

--- a/node-operators/networks/run-a-node/docker.md
+++ b/node-operators/networks/run-a-node/docker.md
@@ -271,6 +271,43 @@ For an overview of the flags used in the following start-up commands, plus addit
 
 ### Collator Node
 
+Beginning with v0.39.0, Moonbeam collator nodes no longer generate session keys automatically on start-up. Run the following command to generate and store on disk the session keys that will be referenced in the start-up command: 
+
+=== "Moonbeam"
+
+    ```bash
+
+    docker run --network="host" -v "/var/lib/moonbeam-data:/data" \
+    -u $(id -u ${USER}):$(id -g ${USER}) \
+    moonbeamfoundation/moonbeam:v0.39.0 key generate-node-key --file /data/node-key
+    
+    ```
+
+=== "Moonriver"
+
+    ```bash
+
+    docker run --network="host" -v "/var/lib/moonriver-data:/data" \
+    -u $(id -u ${USER}):$(id -g ${USER}) \
+    moonbeamfoundation/moonbeam:v0.39.0 key generate-node-key --file /data/node-key
+
+    ```
+
+=== "Moonbase Alpha"
+
+    ```bash
+
+    docker run --network="host" -v "/var/lib/alphanet-data:/data" \
+    -u $(id -u ${USER}):$(id -g ${USER}) \
+    moonbeamfoundation/moonbeam:v0.39.0 key generate-node-key --file /data/node-key
+
+    ```
+
+!!! note
+    This step can be bypassed using the `--unsafe-force-node-key-generation` parameter in the start-up command, although this is not the recommended practice.
+
+Now you can run your Docker start up commands:
+
 ???+ code "Linux snippets"
 
     === "Moonbeam"

--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -334,13 +334,13 @@ For an overview of the flags used in the following start-up commands, plus addit
 
 ### Collator {: #collator }
 
-Beginning with v0.39.0, Moonbeam collator nodes no longer generate session keys automatically on start-up. Run the following command to generate and store on disk the session keys that will be referenced in the start-up command:
+Beginning with v0.39.0, new Moonbeam collator nodes will no longer generate session keys automatically on start-up. When setting up a new node, run the following command to generate and store on disk the session keys that will be referenced in the start-up command:
 
 === "Moonbeam"
 
     ```bash
 
-    /var/lib/moonbeam-data key generate-node-key --file /var/lib/moonbeam-data/node-key
+    /var/lib/moonbeam-data/moonbeam key generate-node-key --file /var/lib/moonbeam-data/node-key
     
     ```
 

--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -334,7 +334,9 @@ For an overview of the flags used in the following start-up commands, plus addit
 
 ### Collator {: #collator }
 
-Beginning with v0.39.0, new Moonbeam collator nodes will no longer generate session keys automatically on start-up. When setting up a new node, run the following command to generate and store on disk the session keys that will be referenced in the start-up command:
+Beginning with v0.39.0, new Moonbeam collator nodes will no longer generate session keys automatically on start-up. Nodes in existence prior to v0.39.0 do not need to make changes to how they handle session keys.
+
+When setting up a new node, run the following command to generate and store on disk the session keys that will be referenced in the start-up command:
 
 === "Moonbeam"
 
@@ -348,7 +350,7 @@ Beginning with v0.39.0, new Moonbeam collator nodes will no longer generate sess
 
     ```bash
 
-    /var/lib/moonriver-data key generate-node-key --file /var/lib/moonriver-data/node-key
+    /var/lib/moonriver-data/moonbeam key generate-node-key --file /var/lib/moonriver-data/node-key
 
     ```
 
@@ -356,7 +358,7 @@ Beginning with v0.39.0, new Moonbeam collator nodes will no longer generate sess
 
     ```bash
 
-    /var/lib/alphanet-data key generate-node-key --file /var/lib/alphanet-data/node-key
+    /var/lib/alphanet-data/moonbeam key generate-node-key --file /var/lib/alphanet-data/node-key
 
     ```
 

--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -334,6 +334,37 @@ For an overview of the flags used in the following start-up commands, plus addit
 
 ### Collator {: #collator }
 
+Beginning with v0.39.0, Moonbeam collator nodes no longer generate session keys automatically on start-up. Run the following command to generate and store on disk the session keys that will be referenced in the start-up command:
+
+=== "Moonbeam"
+
+    ```bash
+
+    /var/lib/moonbeam-data key generate-node-key --file /var/lib/moonbeam-data/node-key
+    
+    ```
+
+=== "Moonriver"
+
+    ```bash
+
+    /var/lib/moonriver-data key generate-node-key --file /var/lib/moonriver-data/node-key
+
+    ```
+
+=== "Moonbase Alpha"
+
+    ```bash
+
+    /var/lib/alphanet-data key generate-node-key --file /var/lib/alphanet-data/node-key
+
+    ```
+
+!!! note
+    This step can be bypassed using the `--unsafe-force-node-key-generation` parameter in the start-up command, although this is not the recommended practice.
+
+Now you can create the systemd configuration file:
+
 === "Moonbeam"
 
     ```bash


### PR DESCRIPTION
### Description

This is an update resulting from breaking changes. Session keys are no longer automatically generated and must be set up and stored by the user before they can run their node services on Docker or Systemd. This PR adds copy and code to inform users of this new requirement and instruct them on generating and storing their session key. 

### Checklist

- [ x] I have added a label to this PR 🏷️
- [ x] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
