### PR TITLE
Update Gas Limit to 60M for Moonbeam

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -823,9 +823,9 @@ networks:
     binary_name: moonbeam
     min_gas_price: 125
     block_time: 6
-    gas_block: 30,000,000
-    gas_block_numbers_only: 30000000 # this should match gas_block, just with no commas
-    gas_tx: 26,000,000 # EXTRINSIC_GAS_LIMIT in test/helpers/constants.ts
+    gas_block: 60,000,000
+    gas_block_numbers_only: 60000000 # this should match gas_block, just with no commas
+    gas_tx: 52,000,000 # EXTRINSIC_GAS_LIMIT in test/helpers/constants.ts
     mbip_5:
       block_storage_limit: 80
       gas_storage_ratio: 366


### PR DESCRIPTION
### Description

Update Gas Limit to 60M for Moonbeam. (as of RT3101)

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
