### PR TITLE
Sidecar Page Quick Fix

### DIFF
--- a/builders/substrate/libraries/sidecar.md
+++ b/builders/substrate/libraries/sidecar.md
@@ -87,7 +87,7 @@ npm install -g @substrate/generate-type-bundle
 Then, navigate to the following directory within your project:
 
 ```bash
-cd /node_modules/@substrate/api-sidecar/build/src/
+cd ./node_modules/@substrate/api-sidecar/build/src/
 ```
 
 Then, run the following command to generate the types bundle for the respective network:


### PR DESCRIPTION
### Description

Fixes a directory link in the sidecar page.

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
