### PR TITLE
fix: typos in documentation files

### DIFF
--- a/.CONTRIBUTING.md
+++ b/.CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your contributions, they are greatly appreciated 💜.
 
 ## Previewing Changes in VS Code
 
-Unfortunately, there is not currrently a way to review the changes locally.
+Unfortunately, there is not currently a way to review the changes locally.
 However, if you're using Visual Studio Code, you can preview the changes you're making to `.md` files before committing them. To learn how, please check out the [Markdown and Visual Studio Code](https://code.visualstudio.com/docs/languages/markdown) guide from the Visual Studio docs site.
 
 ## Structure


### PR DESCRIPTION
Corrected `currrently` to `currently`