### PR TITLE
Add migration for referenda deposits to historical updates page

### DIFF
--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -20,7 +20,7 @@ For invalid transactions where the transaction cost couldn't be paid, the EVM pa
 This bug only impacted Moonriver and Moonbase Alpha and existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed | Impacted Block Range |
-| :------------: | :--------: | :---: | :------------------: |
+|:--------------:|:----------:|:-----:|:--------------------:|
 |   Moonriver    |    RT49    | RT600 |      0 - 455106      |
 | Moonbase Alpha |    RT40    | RT600 |      0 - 675175      |
 
@@ -35,7 +35,7 @@ The Moonbeam fee model for transactions allocates 20% of the fees to the on-chai
 This bug only impacted Moonriver and Moonbase Alpha and existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed | Impacted Block Range |
-| :------------: | :--------: | :---: | :------------------: |
+|:--------------:|:----------:|:-----:|:--------------------:|
 |   Moonriver    |    RT49    | RT800 |      0 - 684728      |
 | Moonbase Alpha |    RT40    | RT800 |      0 - 915684      |
 
@@ -50,7 +50,7 @@ Moonbeam is configured to set the existential deposit to 0, meaning that account
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT900    | RT1001 |       0 - 5164       |
 |   Moonriver    |    RT49    | RT1001 |     0 - 1052241      |
 | Moonbase Alpha |    RT40    | RT1001 |     0 - 1285915      |
@@ -66,7 +66,7 @@ The total delegations for collator candidates were not correctly updated when a 
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT900    | RT1300 |      0 - 524762      |
 |   Moonriver    |    RT49    | RT1300 |     0 - 1541735      |
 | Moonbase Alpha |    RT40    | RT1300 |     0 - 1761128      |
@@ -82,7 +82,7 @@ The `System.NewAccount` event is emitted when a new account is created. However,
 The hotfix was applied in the following block ranges:
 
 |    Network     |                                                              Block Range                                                              |
-| :------------: | :-----------------------------------------------------------------------------------------------------------------------------------: |
+|:--------------:|:-------------------------------------------------------------------------------------------------------------------------------------:|
 |    Moonbeam    | [1041355 - 1041358 and 1100752](https://moonbeam.subscan.io/extrinsic?module=evm&call=hotfix_inc_account_sufficients){target=\_blank} |
 |   Moonriver    |      [1835760 - 1835769](https://moonriver.subscan.io/extrinsic?module=evm&call=hotfix_inc_account_sufficients){target=\_blank}       |
 | Moonbase Alpha |  [2097782 - 2097974](https://moonbase.subscan.io/extrinsic?address=&module=evm&call=hotfix_inc_account_sufficients){target=\_blank}   |
@@ -90,7 +90,7 @@ The hotfix was applied in the following block ranges:
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT900    | RT1401 |      0 - 915320      |
 |   Moonriver    |    RT49    | RT1401 |     0 - 1705939      |
 | Moonbase Alpha |    RT40    | RT1400 |     0 - 1962557      |
@@ -106,7 +106,7 @@ EIP-2612 and Ethereum blocks deal with timestamps in seconds; however, the Subst
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT900    | RT1606 |     0 - 1326697      |
 |   Moonriver    |    RT49    | RT1605 |     0 - 2077598      |
 | Moonbase Alpha |    RT40    | RT1603 |     0 - 2285346      |
@@ -122,7 +122,7 @@ Tips for Substrate-based transactions weren't handled properly. The entire porti
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT900    | RT2403 |     0 - 4163078      |
 |   Moonriver    |    RT49    | RT2401 |     0 - 4668844      |
 | Moonbase Alpha |    RT40    | RT2401 |     0 - 4591616      |
@@ -138,7 +138,7 @@ The reward payouts for all delegations and collators were underestimated wheneve
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT1001   | RT1802 |    5165 - 1919457    |
 |   Moonriver    |   RT1001   | RT1801 |  1052242 - 2572555   |
 | Moonbase Alpha |   RT1001   | RT1800 |  1285916 - 2748785   |
@@ -154,7 +154,7 @@ After EIP-1559 support was introduced, which included the transition to new Ethe
 This bug only impacted Moonbase Alpha and only impacted the following block:
 
 |    Network     | Introduced | Fixed  | Impacted Block |
-| :------------: | :--------: | :----: | :------------: |
+|:--------------:|:----------:|:------:|:--------------:|
 | Moonbase Alpha |   RT1200   | RT1201 |    1648995     |
 
 While the root issue was fixed in RT1201, the incorrect hash was corrected in RT2601.
@@ -170,7 +170,7 @@ With the introduction of EIP-1559 support, the logic for handling `maxFeePerGas`
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT1201   | RT1401 |   415946 - 915320    |
 |   Moonriver    |   RT1201   | RT1401 |  1471037 - 1705939   |
 | Moonbase Alpha |   RT1200   | RT1400 |  1648994 - 1962557   |
@@ -186,7 +186,7 @@ For blocks that included EIP-1559 transactions where a priority fee was applied,
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT1201   | RT1504 |   415946 - 1117309   |
 |   Moonriver    |   RT1201   | RT1504 |  1471037 - 1910639   |
 | Moonbase Alpha |   RT1200   | RT1504 |  1648994 - 2221772   |
@@ -202,7 +202,7 @@ The state root hash was miscalculated for non-legacy transactions as the transac
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT1201   | RT1701 |   415946 - 1581456   |
 |   Moonriver    |   RT1201   | RT1701 |  1471037 - 2281722   |
 | Moonbase Alpha |   RT1200   | RT1700 |  1648994 - 2529735   |
@@ -218,7 +218,7 @@ An upstream bug was introduced to Frontier in the Ethereum Pallet, causing pendi
 Only Moonriver and Moonbase Alpha were impacted. The bug was introduced in the following runtimes and affected the following blocks:
 
 |    Network     | Introduced |   Impacted Blocks   |
-| :------------: | :--------: | :-----------------: |
+|:--------------:|:----------:|:-------------------:|
 |   Moonriver    |   RT1605   | 2077599 and 2077600 |
 | Moonbase Alpha |   RT1603   | 2285347 and 2285348 |
 
@@ -276,7 +276,7 @@ When a non-transactional call, such as `eth_call` or `eth_estimateGas`, is made 
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT1701   | RT1802 |  1581457 - 1919457   |
 |   Moonriver    |   RT1701   | RT1802 |  2281723 - 2616189   |
 | Moonbase Alpha |   RT1700   | RT1802 |  2529736 - 2879402   |
@@ -292,7 +292,7 @@ When multiple remote EVM calls were sent from different accounts with the same t
 This bug only existed on Moonbase Alpha during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 | Moonbase Alpha |   RT1700   | RT1900 |  2529736 - 3069634   |
 
 You can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1790){target=\_blank} for more information.
@@ -306,7 +306,7 @@ There was a difference between estimating the gas for a transaction using a non-
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT1201   | RT2501 |   415946 - 4543267   |
 |   Moonriver    |   RT1201   | RT2500 |  1471037 - 5175574   |
 | Moonbase Alpha |   RT1200   | RT2500 |  1648994 - 5053547   |
@@ -322,7 +322,7 @@ The `effectiveGasPrice` value returned by `eth_getTransactionReceipt` was differ
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-| :------------: | :--------: | :----: | :------------------: |
+|:--------------:|:----------:|:------:|:--------------------:|
 |    Moonbeam    |   RT1201   | RT2801 |   415946 - 5899847   |
 |   Moonriver    |   RT1201   | RT2801 |  1471037 - 6411588   |
 | Moonbase Alpha |   RT1200   | RT2801 |  1648994 - 6209638   |
@@ -344,7 +344,7 @@ This migration updated the now deprecated `Mapping` storage item of the author m
 This migration was only applied to Moonriver and Moonbase Alpha and was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |   Moonriver    |      RT800       |    684728     |
 | Moonbase Alpha |      RT800       |    915684     |
 
@@ -359,7 +359,7 @@ When VRF key support was introduced, the `MappingWithDeposit` storage item of th
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1502      |    1107285    |
 |   Moonriver    |      RT1502      |    1814458    |
 | Moonbase Alpha |      RT1502      |    2112058    |
@@ -375,7 +375,7 @@ A migration was applied to ensure that an account ID can have only one Nimbus ID
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1606      |    1326697    |
 |   Moonriver    |      RT1605      |    2077599    |
 | Moonbase Alpha |      RT1603      |    2285347    |
@@ -393,7 +393,7 @@ This migration sets the `Elasticity` storage item of the base fee pallet to zero
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1300      |    524762     |
 |   Moonriver    |      RT1300      |    1541735    |
 | Moonbase Alpha |      RT1300      |    1761128    |
@@ -413,7 +413,7 @@ There was one preimage that was affected in Moonbeam, which was dropped from the
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT2000      |    3310369    |
 |   Moonriver    |      RT2000      |    3202604    |
 | Moonbase Alpha |      RT2000      |    2673234    |
@@ -429,7 +429,7 @@ A migration was applied to remove the governance V1 collectives, which included 
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT2801      |    5899847    |
 |   Moonriver    |      RT2801      |    6411588    |
 | Moonbase Alpha |      RT2801      |    6209638    |
@@ -439,7 +439,7 @@ For more information, you can review the [relative PR on GitHub](https://github.
 A follow-up migration was required to properly clear the storage entries associated with the governance V1 collectives, which was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT2901      |    6197065    |
 |   Moonriver    |      RT2901      |    6699589    |
 | Moonbase Alpha |      RT2901      |    6710531    |
@@ -455,7 +455,7 @@ A migration was applied to remove the storage associated with the Democracy Pall
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT2901      |    6197065    |
 |   Moonriver    |      RT2901      |    6699589    |
 | Moonbase Alpha |      RT2901      |    6710531    |
@@ -473,7 +473,7 @@ A migration was applied to the Moonbeam Orbiter Pallet that sets the bonds of th
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT2602      |    4977160    |
 |   Moonriver    |      RT2602      |    5638536    |
 | Moonbase Alpha |      RT2601      |    5474345    |
@@ -496,7 +496,7 @@ A migration was applied that updated the `Collator` storage item of the parachai
 This migration was only applied to Moonriver and Moonbase Alpha and was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |   Moonriver    |       RT53       |     9696      |
 | Moonbase Alpha |       RT52       |    238827     |
 
@@ -511,7 +511,7 @@ A migration was applied to the `total` staked amount of the `CollatorState` stor
 This migration was only applied to Moonriver and Moonbase Alpha and was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |   Moonriver    |       RT53       |     9696      |
 | Moonbase Alpha |       RT52       |    238827     |
 
@@ -526,7 +526,7 @@ The exit queue for handling candidate exits had been updated to include support 
 These migrations were only applied to Moonriver and Moonbase Alpha and were executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |   Moonriver    |      RT200       |    259002     |
 | Moonbase Alpha |      RT200       |    457614     |
 
@@ -541,7 +541,7 @@ A migration was applied to purge staking storage bloat for the `Points` and `AtS
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1001      |     5165      |
 |   Moonriver    |      RT1001      |    1052242    |
 | Moonbase Alpha |      RT1001      |    1285916    |
@@ -562,7 +562,7 @@ In addition, a change was made to switch from Nominated Proof of Stake (NPoS) to
 These migrations were executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1001      |     5165      |
 |   Moonriver    |      RT1001      |    1052242    |
 | Moonbase Alpha |      RT1001      |    1285916    |
@@ -578,7 +578,7 @@ A migration was applied to increase the maximum number of delegations per candid
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1101      |    171061     |
 |   Moonriver    |      RT1101      |    1188000    |
 | Moonbase Alpha |      RT1100      |    1426319    |
@@ -598,7 +598,7 @@ This migration splits the deprecated `CandidateState` storage item of the parach
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1201      |    415946     |
 |   Moonriver    |      RT1201      |    1471037    |
 | Moonbase Alpha |      RT1200      |    1648994    |
@@ -614,7 +614,7 @@ There was a migration applied to fix the [Incorrect Collator Selection](#incorre
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1300      |    524762     |
 |   Moonriver    |      RT1300      |    1541735    |
 | Moonbase Alpha |      RT1300      |    1761128    |
@@ -630,7 +630,7 @@ A migration was applied that moved pending delegator requests from the `Delegato
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1502      |    1107285    |
 |   Moonriver    |      RT1502      |    1814458    |
 | Moonbase Alpha |      RT1502      |    2112058    |
@@ -646,7 +646,7 @@ A migration was applied that changed users' staking reserved balances to locked 
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1701      |    1581457    |
 |   Moonriver    |      RT1701      |    2281723    |
 | Moonbase Alpha |      RT1700      |    2529736    |
@@ -665,7 +665,7 @@ To support auto-compounding, two migrations were applied to the `AtStake` storag
 These migrations were executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1901      |    2317683    |
 |   Moonriver    |      RT1901      |    2911863    |
 | Moonbase Alpha |      RT1900      |    3069635    |
@@ -681,7 +681,7 @@ A migration was applied to switch from time-based staking rounds to fixed block-
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT2801      |    5899847    |
 |   Moonriver    |      RT2801      |    6411588    |
 | Moonbase Alpha |      RT2801      |    6209638    |
@@ -697,7 +697,7 @@ Prior to Runtime 3300, the `ReservedForParachainBond` event was emitted once per
 This change took effect at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT3300      |    8381443    |
 |   Moonriver    |      RT3300      |    8894416    |
 | Moonbase Alpha |      RT3300      |    9062316    |
@@ -717,7 +717,7 @@ This stemmed from an upstream change to the [Substrate](https://github.com/parit
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT2302      |    3456477    |
 |   Moonriver    |      RT2302      |    4133065    |
 | Moonbase Alpha |      RT2301      |    4172407    |
@@ -733,7 +733,7 @@ A migration was introduced to support restoring referenda deposits affected by c
 This migration was executed at the following runtimes and blocks:
 
 | Network  | Executed Runtime | Block Applied |
-| :------: | :--------------: | :-----------: |
+|:--------:|:----------------:|:-------------:|
 | Moonbeam |      RT3100      |    7303601    |
 
 ### XCM-Related Pallets {: #xcm-related-pallets }
@@ -749,7 +749,7 @@ There was a migration applied to the `TransactInfo` storage item of the XCM Tran
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1201      |    415946     |
 |   Moonriver    |      RT1201      |    1471037    |
 | Moonbase Alpha |      RT1200      |    1648994    |
@@ -769,7 +769,7 @@ The following three migrations were added to the asset manager pallet to avoid i
 These migrations were executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1201      |    415946     |
 |   Moonriver    |      RT1201      |    1471037    |
 | Moonbase Alpha |      RT1200      |    1648994    |
@@ -785,7 +785,7 @@ A migration was applied to the asset manager pallet, creating a new `SupportedFe
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1300      |    524762     |
 |   Moonriver    |      RT1300      |    1541735    |
 | Moonbase Alpha |      RT1300      |    1761128    |
@@ -801,7 +801,7 @@ With the support of XCM V3, a migration was applied to update the XCM Transactor
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT2302      |    3456477    |
 |   Moonriver    |      RT2302      |    4133065    |
 | Moonbase Alpha |      RT2301      |    4172407    |
@@ -817,7 +817,7 @@ Mintable XC-20s were deprecated in favor of XCM-enabled ERC-20s; as such, a migr
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT2801      |    5899847    |
 |   Moonriver    |      RT2801      |    6411588    |
 | Moonbase Alpha |      RT2801      |    6209638    |
@@ -835,7 +835,7 @@ A breaking change was applied to the Nimbus repository, deprecating `EligibleRat
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-| :------------: | :--------------: | :-----------: |
+|:--------------:|:----------------:|:-------------:|
 |    Moonbeam    |      RT1502      |    1107285    |
 |   Moonriver    |      RT1502      |    1814458    |
 | Moonbase Alpha |      RT1502      |    2112058    |

--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -728,7 +728,7 @@ For more information, you can review the [relative PR on GitHub](https://github.
 
 #### Restore Corrupted Referenda Deposits {: restore-corrupted-referenda-deposits }
 
-A migration was introduced to support restoring referenda deposits affected by corrupted storage values. As the number of values to correct was finite and small, this migration created a list to update them by hand.
+A migration was introduced to support restoring referenda deposits affected by corrupted storage values. The issue arose when a migration was applied twice due to a pallet version error, resulting in invalid values and non-refundable submission deposits. As the number of values to correct was finite and small, this migration created a list to update them by hand.
 
 This migration was executed at the following runtimes and blocks:
 

--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -730,7 +730,7 @@ For more information, you can review the [relative PR on GitHub](https://github.
 
 A migration was introduced to support restoring referenda deposits affected by corrupted storage values. The issue arose when a migration was applied twice due to a pallet version error, resulting in invalid values and non-refundable submission deposits. As the number of values to correct was finite and small, this migration created a list to update them by hand.
 
-This migration was executed at the following runtimes and blocks:
+This migration was only applied to Moonbeam and was executed at the following runtimes and blocks:
 
 | Network  | Executed Runtime | Block Applied |
 |:--------:|:----------------:|:-------------:|

--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -708,6 +708,8 @@ For more information, you can review the [relative PR on GitHub](https://github.
 
 ### Referenda Pallet {: #referenda-pallet }
 
+#### Refunds for Submission Deposits {: #refunds-for-submission-deposits }
+
 A migration was introduced to support refunds for Submission Deposits on closed referenda that updated the `ReferendumInfo` type. The following invariants of `ReferendumInfo` were changed so that the second parameter, `Deposit<AccountId, Balance>`, is now optional, `Option<Deposit<AccountId, Balance>>`: `Approved`, `Rejected`, `Cancelled`, and `TimedOut`.
 
 This stemmed from an upstream change to the [Substrate](https://github.com/paritytech/substrate/pull/12788){target=\_blank} repository.
@@ -723,6 +725,17 @@ This migration was executed at the following runtimes and blocks:
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2134){target=\_blank}.
 
 ***
+
+#### Restore Corrupted Referenda Deposits {: restore-corrupted-referenda-deposits }
+
+A migration was introduced to support restoring corrupted referenda deposits. 
+
+This migration was executed at the following runtimes and blocks:
+
+|    Network     | Executed Runtime | Block Applied |
+|:--------------:|:----------------:|:-------------:|
+|    Moonbeam    |           |        |
+
 
 ### XCM-Related Pallets {: #xcm-related-pallets }
 

--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -710,7 +710,7 @@ For more information, you can review the [relative PR on GitHub](https://github.
 
 #### Refunds for Submission Deposits {: #refunds-for-submission-deposits }
 
-A migration was introduced to support refunds for Submission Deposits on closed referenda that updated the `ReferendumInfo` type. The following invariants of `ReferendumInfo` were changed so that the second parameter, `Deposit<AccountId, Balance>`, is now optional, `Option<Deposit<AccountId, Balance>>`: `Approved`, `Rejected`, `Cancelled`, and `TimedOut`.
+A migration was introduced to support refunds for submission deposits on closed referenda that updated the `ReferendumInfo` type. The following invariants of `ReferendumInfo` were changed so that the second parameter, `Deposit<AccountId, Balance>`, is now optional, `Option<Deposit<AccountId, Balance>>`: `Approved`, `Rejected`, `Cancelled`, and `TimedOut`.
 
 This stemmed from an upstream change to the [Substrate](https://github.com/paritytech/substrate/pull/12788){target=\_blank} repository.
 

--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -20,13 +20,13 @@ For invalid transactions where the transaction cost couldn't be paid, the EVM pa
 This bug only impacted Moonriver and Moonbase Alpha and existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed | Impacted Block Range |
-|:--------------:|:----------:|:-----:|:--------------------:|
+| :------------: | :--------: | :---: | :------------------: |
 |   Moonriver    |    RT49    | RT600 |      0 - 455106      |
 | Moonbase Alpha |    RT40    | RT600 |      0 - 675175      |
 
 For more information, you can review the [relative Frontier PR on GitHub](https://github.com/polkadot-evm/frontier/pull/465){target=\_blank}.
 
-***
+---
 
 #### Ethereum Fees Weren't Sent to Treasury {: #ethereum-fees-to-treasury }
 
@@ -35,13 +35,13 @@ The Moonbeam fee model for transactions allocates 20% of the fees to the on-chai
 This bug only impacted Moonriver and Moonbase Alpha and existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed | Impacted Block Range |
-|:--------------:|:----------:|:-----:|:--------------------:|
+| :------------: | :--------: | :---: | :------------------: |
 |   Moonriver    |    RT49    | RT800 |      0 - 684728      |
 | Moonbase Alpha |    RT40    | RT800 |      0 - 915684      |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/732){target=\_blank}.
 
-***
+---
 
 #### Missing Refunds {: #missing-refunds }
 
@@ -50,14 +50,14 @@ Moonbeam is configured to set the existential deposit to 0, meaning that account
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT900    | RT1001 |       0 - 5164       |
 |   Moonriver    |    RT49    | RT1001 |     0 - 1052241      |
 | Moonbase Alpha |    RT40    | RT1001 |     0 - 1285915      |
 
 For more information, you can review the [relative Frontier PR](https://github.com/polkadot-evm/frontier/pull/509){target=\_blank} and the associated [Substrate PR on GitHub](https://github.com/paritytech/substrate/issues/10117){target=\_blank}.
 
-***
+---
 
 #### Incorrect Collator Selection {: #incorrect-collator-selection }
 
@@ -66,14 +66,14 @@ The total delegations for collator candidates were not correctly updated when a 
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT900    | RT1300 |      0 - 524762      |
 |   Moonriver    |    RT49    | RT1300 |     0 - 1541735      |
 | Moonbase Alpha |    RT40    | RT1300 |     0 - 1761128      |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1291){target=\_blank}.
 
-***
+---
 
 #### New Account Event Bug {: #new-account-event }
 
@@ -82,7 +82,7 @@ The `System.NewAccount` event is emitted when a new account is created. However,
 The hotfix was applied in the following block ranges:
 
 |    Network     |                                                              Block Range                                                              |
-|:--------------:|:-------------------------------------------------------------------------------------------------------------------------------------:|
+| :------------: | :-----------------------------------------------------------------------------------------------------------------------------------: |
 |    Moonbeam    | [1041355 - 1041358 and 1100752](https://moonbeam.subscan.io/extrinsic?module=evm&call=hotfix_inc_account_sufficients){target=\_blank} |
 |   Moonriver    |      [1835760 - 1835769](https://moonriver.subscan.io/extrinsic?module=evm&call=hotfix_inc_account_sufficients){target=\_blank}       |
 | Moonbase Alpha |  [2097782 - 2097974](https://moonbase.subscan.io/extrinsic?address=&module=evm&call=hotfix_inc_account_sufficients){target=\_blank}   |
@@ -90,14 +90,14 @@ The hotfix was applied in the following block ranges:
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT900    | RT1401 |      0 - 915320      |
 |   Moonriver    |    RT49    | RT1401 |     0 - 1705939      |
 | Moonbase Alpha |    RT40    | RT1400 |     0 - 1962557      |
 
 For more information, you can review the [relative Frontier PR on GitHub](https://github.com/moonbeam-foundation/frontier/pull/46/files){target=\_blank}.
 
-***
+---
 
 #### Incorrect Timestamp Units {: #incorrect-timestamp-units }
 
@@ -106,14 +106,14 @@ EIP-2612 and Ethereum blocks deal with timestamps in seconds; however, the Subst
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT900    | RT1606 |     0 - 1326697      |
 |   Moonriver    |    RT49    | RT1605 |     0 - 2077598      |
 | Moonbase Alpha |    RT40    | RT1603 |     0 - 2285346      |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1451){target=\_blank}.
 
-***
+---
 
 #### Substrate Tips Missing Treasury Distribution {: #substrate-tips }
 
@@ -122,14 +122,14 @@ Tips for Substrate-based transactions weren't handled properly. The entire porti
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT900    | RT2403 |     0 - 4163078      |
 |   Moonriver    |    RT49    | RT2401 |     0 - 4668844      |
 | Moonbase Alpha |    RT40    | RT2401 |     0 - 4591616      |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2291){target=\_blank}.
 
-***
+---
 
 #### Incorrect Delegation Reward Calculation {: #incorrect-delegation-reward-calculation }
 
@@ -138,14 +138,14 @@ The reward payouts for all delegations and collators were underestimated wheneve
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT1001   | RT1802 |    5165 - 1919457    |
 |   Moonriver    |   RT1001   | RT1801 |  1052242 - 2572555   |
 | Moonbase Alpha |   RT1001   | RT1800 |  1285916 - 2748785   |
 
 You can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1719){target=\_blank} for more information.
 
-***
+---
 
 #### Block Parent Hash Calculated Incorrectly {: #block-parent-hash-calculated-incorrectly }
 
@@ -154,14 +154,14 @@ After EIP-1559 support was introduced, which included the transition to new Ethe
 This bug only impacted Moonbase Alpha and only impacted the following block:
 
 |    Network     | Introduced | Fixed  | Impacted Block |
-|:--------------:|:----------:|:------:|:--------------:|
+| :------------: | :--------: | :----: | :------------: |
 | Moonbase Alpha |   RT1200   | RT1201 |    1648995     |
 
 While the root issue was fixed in RT1201, the incorrect hash was corrected in RT2601.
 
 For more information on the root fix, you can review the [relative Frontier PR on GitHub](https://github.com/polkadot-evm/frontier/pull/570/){target=\_blank}. To take a look at the correction of the parent hash, check out the corresponding [Moonbeam PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2524){target=\_blank}.
 
-***
+---
 
 #### Incorrect Handling of EIP-1559 Gas Fees {: #incorrect-gas-fees-eip1559 }
 
@@ -170,14 +170,14 @@ With the introduction of EIP-1559 support, the logic for handling `maxFeePerGas`
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT1201   | RT1401 |   415946 - 915320    |
 |   Moonriver    |   RT1201   | RT1401 |  1471037 - 1705939   |
 | Moonbase Alpha |   RT1200   | RT1400 |  1648994 - 1962557   |
 
 For more information, you can review the [relative Frontier PR](https://github.com/moonbeam-foundation/frontier/pull/45){target=\_blank}.
 
-***
+---
 
 #### Transaction Fees Paid to Collators {: #transaction-fees-paid-to-collators }
 
@@ -186,14 +186,14 @@ For blocks that included EIP-1559 transactions where a priority fee was applied,
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT1201   | RT1504 |   415946 - 1117309   |
 |   Moonriver    |   RT1201   | RT1504 |  1471037 - 1910639   |
 | Moonbase Alpha |   RT1200   | RT1504 |  1648994 - 2221772   |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1528){target=\_blank}.
 
-***
+---
 
 #### Incorrect State Root Hash {: #incorrect-state-root-hash }
 
@@ -202,14 +202,14 @@ The state root hash was miscalculated for non-legacy transactions as the transac
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT1201   | RT1701 |   415946 - 1581456   |
 |   Moonriver    |   RT1201   | RT1701 |  1471037 - 2281722   |
 | Moonbase Alpha |   RT1200   | RT1700 |  1648994 - 2529735   |
 
 For more information, you can review the [relative Frontier PR](https://github.com/moonbeam-foundation/frontier/pull/86){target=\_blank} and [Moonbeam PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1678/files){target=\_blank}.
 
-***
+---
 
 #### Ethereum Transactions Duplicated in Storage {: #ethereum-transactions-duplicated-in-storage }
 
@@ -218,7 +218,7 @@ An upstream bug was introduced to Frontier in the Ethereum Pallet, causing pendi
 Only Moonriver and Moonbase Alpha were impacted. The bug was introduced in the following runtimes and affected the following blocks:
 
 |    Network     | Introduced |   Impacted Blocks   |
-|:--------------:|:----------:|:-------------------:|
+| :------------: | :--------: | :-----------------: |
 |   Moonriver    |   RT1605   | 2077599 and 2077600 |
 | Moonbase Alpha |   RT1603   | 2285347 and 2285348 |
 
@@ -267,7 +267,7 @@ The duplicated transactions belong to the first block. So, on Moonriver, the tra
 
 For more information, you can review the [relative Frontier PR on GitHub](https://github.com/polkadot-evm/frontier/pull/638){target=\_blank}.
 
-***
+---
 
 #### Gas Limit Too High for Non-Transactional Calls {: #gas-limit-too-high-for-non-transactional-calls }
 
@@ -276,14 +276,14 @@ When a non-transactional call, such as `eth_call` or `eth_estimateGas`, is made 
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT1701   | RT1802 |  1581457 - 1919457   |
 |   Moonriver    |   RT1701   | RT1802 |  2281723 - 2616189   |
 | Moonbase Alpha |   RT1700   | RT1802 |  2529736 - 2879402   |
 
 You can review the [relative Frontier PR on GitHub](https://github.com/polkadot-evm/frontier/pull/935){target=\_blank} for more information.
 
-***
+---
 
 #### Remote EVM Calls Return Identical Transaction Hashes {: #remote-evm-calls-return-identical-tx-hashes }
 
@@ -292,12 +292,12 @@ When multiple remote EVM calls were sent from different accounts with the same t
 This bug only existed on Moonbase Alpha during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 | Moonbase Alpha |   RT1700   | RT1900 |  2529736 - 3069634   |
 
 You can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1790){target=\_blank} for more information.
 
-***
+---
 
 #### Gas Estimation Discrepancy {: #gas-estimation-discrepancy }
 
@@ -306,14 +306,14 @@ There was a difference between estimating the gas for a transaction using a non-
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT1201   | RT2501 |   415946 - 4543267   |
 |   Moonriver    |   RT1201   | RT2500 |  1471037 - 5175574   |
 | Moonbase Alpha |   RT1200   | RT2500 |  1648994 - 5053547   |
 
 You can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1790/){target=\_blank} for more information.
 
-***
+---
 
 #### Incorrect Effective Gas Price In Transaction Receipts {: #incorrect-effective-gas-price }
 
@@ -322,14 +322,14 @@ The `effectiveGasPrice` value returned by `eth_getTransactionReceipt` was differ
 This bug existed during the following runtimes and block ranges:
 
 |    Network     | Introduced | Fixed  | Impacted Block Range |
-|:--------------:|:----------:|:------:|:--------------------:|
+| :------------: | :--------: | :----: | :------------------: |
 |    Moonbeam    |   RT1201   | RT2801 |   415946 - 5899847   |
 |   Moonriver    |   RT1201   | RT2801 |  1471037 - 6411588   |
 | Moonbase Alpha |   RT1200   | RT2801 |  1648994 - 6209638   |
 
 You can review the [relative Frontier PR](https://github.com/polkadot-evm/frontier/pull/1280){target=\_blank} and [Moonbeam PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2610){target=\_blank} for more information.
 
-***
+---
 
 ## Migrations {: #migrations }
 
@@ -344,13 +344,13 @@ This migration updated the now deprecated `Mapping` storage item of the author m
 This migration was only applied to Moonriver and Moonbase Alpha and was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |   Moonriver    |      RT800       |    684728     |
 | Moonbase Alpha |      RT800       |    915684     |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/679){target=\_blank}.
 
-***
+---
 
 #### Add Support for VRF Keys {: #add-support-for-vrf-keys }
 
@@ -359,14 +359,14 @@ When VRF key support was introduced, the `MappingWithDeposit` storage item of th
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1502      |    1107285    |
 |   Moonriver    |      RT1502      |    1814458    |
 | Moonbase Alpha |      RT1502      |    2112058    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1407){target=\_blank}.
 
-***
+---
 
 #### One Nimbus ID per Account ID {: #one-nimbus-id-per-account-id }
 
@@ -375,14 +375,14 @@ A migration was applied to ensure that an account ID can have only one Nimbus ID
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1606      |    1326697    |
 |   Moonriver    |      RT1605      |    2077599    |
 | Moonbase Alpha |      RT1603      |    2285347    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1525){target=\_blank}.
 
-***
+---
 
 ### Base Fee Pallet {: #base-fee }
 
@@ -393,14 +393,14 @@ This migration sets the `Elasticity` storage item of the base fee pallet to zero
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1300      |    524762     |
 |   Moonriver    |      RT1300      |    1541735    |
 | Moonbase Alpha |      RT1300      |    1761128    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1744){target=\_blank}.
 
-***
+---
 
 ### Democracy Pallet {: #democracy }
 
@@ -413,14 +413,14 @@ There was one preimage that was affected in Moonbeam, which was dropped from the
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT2000      |    3310369    |
 |   Moonriver    |      RT2000      |    3202604    |
 | Moonbase Alpha |      RT2000      |    2673234    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1962){target=\_blank}.
 
-***
+---
 
 #### Remove Governance V1 Collectives {: #remove-gov-v1-collectives }
 
@@ -429,7 +429,7 @@ A migration was applied to remove the governance V1 collectives, which included 
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT2801      |    5899847    |
 |   Moonriver    |      RT2801      |    6411588    |
 | Moonbase Alpha |      RT2801      |    6209638    |
@@ -439,14 +439,14 @@ For more information, you can review the [relative PR on GitHub](https://github.
 A follow-up migration was required to properly clear the storage entries associated with the governance V1 collectives, which was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT2901      |    6197065    |
 |   Moonriver    |      RT2901      |    6699589    |
 | Moonbase Alpha |      RT2901      |    6710531    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2711){target=\_blank}.
 
-***
+---
 
 #### Remove Governance V1 Democracy Pallet {: #remove-gov-v1-collectives }
 
@@ -455,14 +455,14 @@ A migration was applied to remove the storage associated with the Democracy Pall
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT2901      |    6197065    |
 |   Moonriver    |      RT2901      |    6699589    |
 | Moonbase Alpha |      RT2901      |    6710531    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2685){target=\_blank}.
 
-***
+---
 
 ### Moonbeam Orbiter Pallet {: #moonbeam-orbiter }
 
@@ -473,14 +473,14 @@ A migration was applied to the Moonbeam Orbiter Pallet that sets the bonds of th
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT2602      |    4977160    |
 |   Moonriver    |      RT2602      |    5638536    |
 | Moonbase Alpha |      RT2601      |    5474345    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2526){target=\_blank}.
 
-***
+---
 
 ### Parachain Staking Pallet {: #parachain-staking }
 
@@ -496,13 +496,13 @@ A migration was applied that updated the `Collator` storage item of the parachai
 This migration was only applied to Moonriver and Moonbase Alpha and was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |   Moonriver    |       RT53       |     9696      |
 | Moonbase Alpha |       RT52       |    238827     |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/505){target=\_blank}.
 
-***
+---
 
 #### Patch Total Staked Amount {: #patch-total-staked-amount }
 
@@ -511,28 +511,28 @@ A migration was applied to the `total` staked amount of the `CollatorState` stor
 This migration was only applied to Moonriver and Moonbase Alpha and was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |   Moonriver    |       RT53       |     9696      |
 | Moonbase Alpha |       RT52       |    238827     |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/502){target=\_blank}.
 
-***
+---
 
 #### Support Delayed Nominator (Delegator) Exits {: #support-delayed-nominator-exits }
 
-The exit queue for handling candidate exits had been updated to include support for delayed nominator (delegator) exits and revocations, which required a migration to update the `ExitQueue` parachain staking pallet storage item to `ExitQueue2`. The `NominatorState` storage item was also migrated to `NominatorState2`  to prevent a nominator from performing more nominations when they already have scheduled an exit.
+The exit queue for handling candidate exits had been updated to include support for delayed nominator (delegator) exits and revocations, which required a migration to update the `ExitQueue` parachain staking pallet storage item to `ExitQueue2`. The `NominatorState` storage item was also migrated to `NominatorState2` to prevent a nominator from performing more nominations when they already have scheduled an exit.
 
 These migrations were only applied to Moonriver and Moonbase Alpha and were executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |   Moonriver    |      RT200       |    259002     |
 | Moonbase Alpha |      RT200       |    457614     |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/610){target=\_blank}.
 
-***
+---
 
 #### Purge Staking Storage Bloat {: #purge-staking-storage-bloat }
 
@@ -541,14 +541,14 @@ A migration was applied to purge staking storage bloat for the `Points` and `AtS
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1001      |     5165      |
 |   Moonriver    |      RT1001      |    1052242    |
 | Moonbase Alpha |      RT1001      |    1285916    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/970){target=\_blank}.
 
-***
+---
 
 #### Support Manual Exits and DPoS Terminology {: #support-manual-exits-dpos-terminology }
 
@@ -562,14 +562,14 @@ In addition, a change was made to switch from Nominated Proof of Stake (NPoS) to
 These migrations were executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1001      |     5165      |
 |   Moonriver    |      RT1001      |    1052242    |
 | Moonbase Alpha |      RT1001      |    1285916    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/810){target=\_blank}.
 
-***
+---
 
 #### Increase Max Delegations per Candidate {: #increase-max-delegations-per-candidate }
 
@@ -578,14 +578,14 @@ A migration was applied to increase the maximum number of delegations per candid
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1101      |    171061     |
 |   Moonriver    |      RT1101      |    1188000    |
 | Moonbase Alpha |      RT1100      |    1426319    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1096){target=\_blank}.
 
-***
+---
 
 #### Split Candidate Delegations into Top and Bottom {: #split-candidate-delegations-top-bottom }
 
@@ -598,14 +598,14 @@ This migration splits the deprecated `CandidateState` storage item of the parach
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1201      |    415946     |
 |   Moonriver    |      RT1201      |    1471037    |
 | Moonbase Alpha |      RT1200      |    1648994    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1117){target=\_blank}.
 
-***
+---
 
 #### Patch Incorrect Total Delegations {: #patch-incorrect-total-delegations }
 
@@ -614,30 +614,30 @@ There was a migration applied to fix the [Incorrect Collator Selection](#incorre
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1300      |    524762     |
 |   Moonriver    |      RT1300      |    1541735    |
 | Moonbase Alpha |      RT1300      |    1761128    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1291){target=\_blank}.
 
-***
+---
 
 #### Split Delegator State into Delegation Scheduled Requests {: #split-delegator-state }
 
-A migration was applied that moved pending delegator requests from the `DelegatorState` storage item of the parachain staking pallet into a new `DelegationScheduledRequests` storage item. 
+A migration was applied that moved pending delegator requests from the `DelegatorState` storage item of the parachain staking pallet into a new `DelegationScheduledRequests` storage item.
 
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1502      |    1107285    |
 |   Moonriver    |      RT1502      |    1814458    |
 | Moonbase Alpha |      RT1502      |    2112058    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1408){target=\_blank}.
 
-***
+---
 
 #### Replace Staking Reserves with Locks {: #replace-staking-reserves }
 
@@ -646,33 +646,33 @@ A migration was applied that changed users' staking reserved balances to locked 
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1701      |    1581457    |
 |   Moonriver    |      RT1701      |    2281723    |
 | Moonbase Alpha |      RT1700      |    2529736    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1604){target=\_blank}.
 
-***
+---
 
 #### Auto-Compounding Support {: #auto-compounding-support }
 
 To support auto-compounding, two migrations were applied to the `AtStake` storage item in the parachain staking pallet:
 
-- `RemovePaidRoundsFromAtStake` -  to remove any stale `AtStake` entries relating to already paid-out rounds with candidates that didn't produce any blocks. This migration is a prerequisite for the `MigrateAtStakeAutoCompound` migration
-- `MigrateAtStakeAutoCompound` -  migrates the snapshots for unpaid rounds for `AtStake` entries
+- `RemovePaidRoundsFromAtStake` - to remove any stale `AtStake` entries relating to already paid-out rounds with candidates that didn't produce any blocks. This migration is a prerequisite for the `MigrateAtStakeAutoCompound` migration
+- `MigrateAtStakeAutoCompound` - migrates the snapshots for unpaid rounds for `AtStake` entries
 
 These migrations were executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1901      |    2317683    |
 |   Moonriver    |      RT1901      |    2911863    |
 | Moonbase Alpha |      RT1900      |    3069635    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1878){target=\_blank}.
 
-***
+---
 
 #### Switch to Block-Based Staking Rounds {: #block-based-staking-rounds }
 
@@ -681,14 +681,14 @@ A migration was applied to switch from time-based staking rounds to fixed block-
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT2801      |    5899847    |
 |   Moonriver    |      RT2801      |    6411588    |
 | Moonbase Alpha |      RT2801      |    6209638    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2690){target=\_blank}.
 
-***
+---
 
 #### Renaming of Parachain Bond Reserve Events {: #renaming-of-parachain-bond-reserve-events }
 
@@ -697,14 +697,14 @@ Prior to Runtime 3300, the `ReservedForParachainBond` event was emitted once per
 This change took effect at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT3300      |    8381443    |
 |   Moonriver    |      RT3300      |    8894416    |
 | Moonbase Alpha |      RT3300      |    9062316    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2976){target=\_blank}.
 
-***
+---
 
 ### Referenda Pallet {: #referenda-pallet }
 
@@ -717,14 +717,14 @@ This stemmed from an upstream change to the [Substrate](https://github.com/parit
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT2302      |    3456477    |
 |   Moonriver    |      RT2302      |    4133065    |
 | Moonbase Alpha |      RT2301      |    4172407    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2134){target=\_blank}.
 
-***
+---
 
 #### Restore Corrupted Referenda Deposits {: restore-corrupted-referenda-deposits }
 
@@ -732,10 +732,9 @@ A migration was introduced to support restoring corrupted referenda deposits.
 
 This migration was executed at the following runtimes and blocks:
 
-|    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
-|    Moonbeam    |           |        |
-
+| Network  | Executed Runtime | Block Applied |
+| :------: | :--------------: | :-----------: |
+| Moonbeam |      RT3100      |               |
 
 ### XCM-Related Pallets {: #xcm-related-pallets }
 
@@ -750,34 +749,34 @@ There was a migration applied to the `TransactInfo` storage item of the XCM Tran
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1201      |    415946     |
 |   Moonriver    |      RT1201      |    1471037    |
 | Moonbase Alpha |      RT1200      |    1648994    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1114){target=\_blank}.
 
-***
+---
 
 #### Add Support for Kusama Asset Hub (Statemine) Prefix Breaking Change {: #add-support-statemine-prefix }
 
 The following three migrations were added to the asset manager pallet to avoid issues with Kusama Asset Hub's (previously referred to as Statemine) [breaking change to the way it represents assets](https://github.com/paritytech/cumulus/pull/831){target=\_blank} and possible future breaking changes:
 
-- `UnitsWithAssetType` - updates the `AssetTypeUnitsPerSecond` storage item  to a mapping of the `AssetType` to `units_per_second`, instead of the mapping `AssetId` to `units_per_second`. This is done to avoid additional migrations whenever a breaking change arises
+- `UnitsWithAssetType` - updates the `AssetTypeUnitsPerSecond` storage item to a mapping of the `AssetType` to `units_per_second`, instead of the mapping `AssetId` to `units_per_second`. This is done to avoid additional migrations whenever a breaking change arises
 - `PopulateAssetTypeIdStorage` - creates a new `AssetTypeId` storage item that holds the `AssetType` to `AssetId` mapping, which allows the decoupling of `assetIds` and `AssetTypes`
 - `ChangeStateminePrefixes` - updates already registered Kusama Asset Hub (Statemine) assets to their new form
 
 These migrations were executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1201      |    415946     |
 |   Moonriver    |      RT1201      |    1471037    |
 | Moonbase Alpha |      RT1200      |    1648994    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1159){target=\_blank}.
 
-***
+---
 
 #### Add New Supported Fee Payment Assets Storage Item {: #add-supported-fee-payment-assets }
 
@@ -786,14 +785,14 @@ A migration was applied to the asset manager pallet, creating a new `SupportedFe
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1300      |    524762     |
 |   Moonriver    |      RT1300      |    1541735    |
 | Moonbase Alpha |      RT1300      |    1761128    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/1118){target=\_blank}.
 
-***
+---
 
 #### Update the XCM Transactor Storage from V2 to V3 {: #update-xcm-transactor }
 
@@ -802,14 +801,14 @@ With the support of XCM V3, a migration was applied to update the XCM Transactor
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT2302      |    3456477    |
 |   Moonriver    |      RT2302      |    4133065    |
 | Moonbase Alpha |      RT2301      |    4172407    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2145){target=\_blank}.
 
-***
+---
 
 #### Remove Mintable XC-20s {: #remove-local-assets }
 
@@ -818,14 +817,14 @@ Mintable XC-20s were deprecated in favor of XCM-enabled ERC-20s; as such, a migr
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT2801      |    5899847    |
 |   Moonriver    |      RT2801      |    6411588    |
 | Moonbase Alpha |      RT2801      |    6209638    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2634){target=\_blank}.
 
-***
+---
 
 ### Nimbus Author Filter Pallet {: #nimbus }
 
@@ -836,7 +835,7 @@ A breaking change was applied to the Nimbus repository, deprecating `EligibleRat
 This migration was executed at the following runtimes and blocks:
 
 |    Network     | Executed Runtime | Block Applied |
-|:--------------:|:----------------:|:-------------:|
+| :------------: | :--------------: | :-----------: |
 |    Moonbeam    |      RT1502      |    1107285    |
 |   Moonriver    |      RT1502      |    1814458    |
 | Moonbase Alpha |      RT1502      |    2112058    |

--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -728,7 +728,7 @@ For more information, you can review the [relative PR on GitHub](https://github.
 
 #### Restore Corrupted Referenda Deposits {: restore-corrupted-referenda-deposits }
 
-A migration was introduced to support restoring corrupted referenda deposits.
+A migration was introduced to support restoring referenda deposits affected by corrupted storage values. As the number of values to correct was finite and small, this migration created a list to update them by hand.
 
 This migration was executed at the following runtimes and blocks:
 

--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -728,13 +728,13 @@ For more information, you can review the [relative PR on GitHub](https://github.
 
 #### Restore Corrupted Referenda Deposits {: restore-corrupted-referenda-deposits }
 
-A migration was introduced to support restoring corrupted referenda deposits. 
+A migration was introduced to support restoring corrupted referenda deposits.
 
 This migration was executed at the following runtimes and blocks:
 
 | Network  | Executed Runtime | Block Applied |
 | :------: | :--------------: | :-----------: |
-| Moonbeam |      RT3100      |               |
+| Moonbeam |      RT3100      |    7303601    |
 
 ### XCM-Related Pallets {: #xcm-related-pallets }
 


### PR DESCRIPTION
### Description

This PR:
- adds information re: restoring referenda deposits for accounts with value corruption related to an engineering issue

The PR where the code changes were made:  https://github.com/moonbeam-foundation/moonbeam/pull/2872

### Checklist

- [ x] I have added a label to this PR 🏷️
- [ x] I have run my changes through Grammarly

