### PR TITLE
chore: fix 404 status URL

### DIFF
--- a/.CONTRIBUTING.md
+++ b/.CONTRIBUTING.md
@@ -37,7 +37,7 @@ Some important things to note:
 - Files follow the convention of 'Display Name': 'file-name.md'
 - Subdirectories are listed by their directory name in the source code
 
-Both, **Canonical Contracts** and **Contract Addresses** are displayed in the left side navigation menu and on the landing page. The **Precompiled Contracts** title, comes from the `title` of the [`.pages` file for the `precompiles` subdirectory](https://github.com/moonbeam-foundation/moonbeam-docs/blob/master/builders/ethereum/canonical-contracts/precompiles/.pages).
+Both, **Canonical Contracts** and **Contract Addresses** are displayed in the left side navigation menu and on the landing page. The **Precompiled Contracts** title, comes from the `title` of the [`.pages` file for the `precompiles` subdirectory](https://github.com/moonbeam-foundation/moonbeam-docs/blob/master/builders/ethereum/precompiles/.pages).
 
 ![Display titles](/images/readme-contributing/contributing-1.webp)
 


### PR DESCRIPTION
### Description

The link has expired, replace it with the latest address

### Checklist

- [ ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
