### PR TITLE
fix: typographical errors

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -8,7 +8,7 @@ Please explain the changes this PR addresses here.
 - [ ] I have run my changes through Grammarly
 - [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
 - [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
-- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
+- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the Chinese repo
     - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
 - [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
 - [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
@@ -22,7 +22,7 @@ Please link to any corresponding PRs here.
 
 - [ ] Will need to create PR in `moonbeam-docs` repo to remove images
 - [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
-- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
+- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for the Chinese site
 - [ ] No additional PRs are required after the translations are done
 
 #### Items to be Updated

--- a/.snippets/code/builders/ethereum/precompiles/account/identity/Identity.sol
+++ b/.snippets/code/builders/ethereum/precompiles/account/identity/Identity.sol
@@ -14,7 +14,7 @@ Identity constant IDENTITY_CONTRACT = Identity(IDENTITY_ADDRESS);
 interface Identity {
     /// @dev Associated raw data.
     struct Data {
-        /// Is `true` if it represents data, else the absense of data is represented by `false`.
+        /// Is `true` if it represents data, else the absence of data is represented by `false`.
         bool hasData;
         /// The contained value.
         bytes value;
@@ -74,9 +74,9 @@ interface Identity {
 
     /// @dev Represents an additional field in identity info.
     struct Additional {
-        /// The assciated key.
+        /// The associated key.
         Data key;
-        /// The assciated value.
+        /// The associated value.
         Data value;
     }
 
@@ -236,7 +236,7 @@ interface Identity {
     /// @dev Rename a "sub" identity account of the caller.
     /// @custom:selector 452df561
     /// @param sub The sub account
-    /// @param data The new assocaited data
+    /// @param data The new associated data
     function renameSub(address sub, Data memory data) external;
 
     /// @dev Removes a "sub" identity account of the caller.

--- a/.snippets/code/builders/ethereum/precompiles/ux/batch/Batch.sol
+++ b/.snippets/code/builders/ethereum/precompiles/ux/batch/Batch.sol
@@ -9,7 +9,7 @@ Batch constant BATCH_CONTRACT = Batch(BATCH_ADDRESS);
 
 /// @author The Moonbeam Team
 /// @title Batch precompile
-/// @dev Allows to perform multiple calls throught one call to the precompile.
+/// @dev Allows to perform multiple calls through one call to the precompile.
 /// Can be used by EOA to do multiple calls in a single transaction.
 /// @custom:address 0x0000000000000000000000000000000000000808
 interface Batch {

--- a/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-precompile/XcmTransactorV2.sol
+++ b/.snippets/code/builders/interoperability/xcm/remote-execution/substrate-calls/xcm-transactor-precompile/XcmTransactorV2.sol
@@ -99,10 +99,10 @@ interface XcmTransactorV2 {
     /// Transact through XCM using fee based on its multilocation through signed origins
     /// @custom:selector d7ab340c
     /// @dev No token is burnt before sending the message. The caller must ensure the destination
-    /// is able to undertand the DescendOrigin message, and create a unique account from which
+    /// is able to understand the DescendOrigin message, and create a unique account from which
     /// dispatch the call
     /// @param dest The destination chain (as multilocation) where to send the message
-    /// @param feeLocation The asset multilocation that indentifies the fee payment currency
+    /// @param feeLocation The asset multilocation that identifies the fee payment currency
     /// It has to be a reserve of the destination chain
     /// @param transactRequiredWeightAtMost The weight we want to buy in the destination chain for the call to be made
     /// @param call The call to be executed in the destination chain
@@ -120,7 +120,7 @@ interface XcmTransactorV2 {
     /// Transact through XCM using fee based on its erc20 address through signed origins
     /// @custom:selector b648f3fe
     /// @dev No token is burnt before sending the message. The caller must ensure the destination
-    /// is able to undertand the DescendOrigin message, and create a unique account from which
+    /// is able to understand the DescendOrigin message, and create a unique account from which
     /// dispatch the call
     /// @param dest The destination chain (as multilocation) where to send the message
     /// @param feeLocationAddress The ERC20 address of the token we want to use to pay for fees


### PR DESCRIPTION
## Description:
This PR fixes multiple typographical errors across the repository, ensuring consistency and accuracy in comments and documentation. Changes include corrections to spelling mistakes such as "assciated" to "associated," "undertand" to "understand," and similar issues. These edits enhance the readability and professionalism of the codebase without altering functionality.

## Checklist:
- [x] I have added a label to this PR 🏷️  
- [x] I have run my changes through Grammarly  
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira  
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects  
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the Chinese repo  
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`  
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.  
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables  
- [ ] If this page requires a disclaimer, I have added one  

## Corresponding PRs:
N/A  

## After Translation Requirements:
- [ ] Will need to create PR in `moonbeam-docs` repo to remove images  
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables  
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for the Chinese site  
- [ ] No additional PRs are required after the translations are done  

## Items to be Updated:
N/A
