### PR TITLE
fix typos

### DIFF
--- a/.snippets/code/builders/ethereum/json-rpc/pubsub/subscribe-to-event-logs.js
+++ b/.snippets/code/builders/ethereum/json-rpc/pubsub/subscribe-to-event-logs.js
@@ -15,7 +15,7 @@ const main = async () => {
     }
   );
 
-  console.log('🕔 Subscrition set up. Waiting for new logs');
+  console.log('🕔 Subscription set up. Waiting for new logs');
 
   subscsription.on('connected', function (subscriptionId) {
     console.log(subscriptionId);

--- a/.snippets/code/builders/ethereum/json-rpc/pubsub/use-wildcards.js
+++ b/.snippets/code/builders/ethereum/json-rpc/pubsub/use-wildcards.js
@@ -19,7 +19,7 @@ const main = async () => {
     }
   );
 
-  console.log("🕔 Subscrition set up. Waiting for new logs")
+  console.log("🕔 Subscription set up. Waiting for new logs")
 
   subscription.on('connected', function (subscriptionId) {
     console.log(subscriptionId);

--- a/.snippets/code/builders/ethereum/precompiles/features/randomness/RandomnessConsumer.sol
+++ b/.snippets/code/builders/ethereum/precompiles/features/randomness/RandomnessConsumer.sol
@@ -65,7 +65,7 @@ address constant RANDOMNESS_ADDRESS = 0x0000000000000000000000000000000000000809
  * @dev your contract's user-significant behavior.
  *
  * @dev Since the output of the random words generated for
- * @dev *requestLocalVRFRandomWords* is dependant of the collator producing the
+ * @dev *requestLocalVRFRandomWords* is dependent on the collator producing the
  * @dev block at fulfillment, the collator could skip its block forcing the
  * @dev fulfillment to be executed by a different collator, and therefore
  * @dev generating a different VRF.

--- a/.snippets/code/builders/ethereum/precompiles/features/staking/StakingInterface.sol
+++ b/.snippets/code/builders/ethereum/precompiles/features/staking/StakingInterface.sol
@@ -24,11 +24,11 @@ interface ParachainStaking {
 
     /// @dev Check whether the specified address is currently a collator candidate
     /// @custom:selector d51b9e93
-    /// @param candidate the address that we want to confirm is a collator andidate
+    /// @param candidate the address that we want to confirm is a collator candidate
     /// @return A boolean confirming whether the address is a collator candidate
     function isCandidate(address candidate) external view returns (bool);
 
-    /// @dev Check whether the specifies address is currently a part of the active set
+    /// @dev Check whether the specified address is currently a part of the active set
     /// @custom:selector 740d7d2a
     /// @param candidate the address that we want to confirm is a part of the active set
     /// @return A boolean confirming whether the address is a part of the active set
@@ -136,9 +136,9 @@ interface ParachainStaking {
         address candidate
     ) external view returns (bool);
 
-    /// @dev Whether there exists a pending bond less request made by a candidate
+    /// @dev Whether there exists a pending bondless request made by a candidate
     /// @custom:selector d0deec11
-    /// @param candidate the candidate which made the request
+    /// @param candidate the candidate who made the request
     /// @return Whether a pending bond less request was made by the candidate
     function candidateRequestIsPending(
         address candidate


### PR DESCRIPTION
### Description

This pull request addresses multiple typos across various files in the project. These corrections improve the clarity and accuracy of the code and documentation.

**Changes include:**
- Corrected spelling errors such as "Subscrition" to "Subscription," "dependant" to "dependent," and "andidate" to "candidate."
- Updated comments, console logs, and documentation in affected files.

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths in the Chinese repo
- [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images
- [ ] If variables (`variables.yml`) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

N/A

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for the Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

N/A

---

Allow edits by maintainers: ✅
