### PR TITLE
1RPC URL

### DIFF
--- a/builders/get-started/endpoints.md
+++ b/builders/get-started/endpoints.md
@@ -40,11 +40,11 @@ You can create your own endpoint suitable for development or production use usin
 
 ### 1RPC {: #1rpc}
 
-[1RPC](https://www.1rpc.io){target=\_blank} is a free and private RPC relay that protects user privacy by preventing data collection, user tracking, phishing attempts from other parties. It tunnels user requests via distributed relays to other RPC providers whilst preventing the tracking of user metadata such as IP address, device information and wallet linkability with secure enclave technology.
+[1RPC](https://docs.1rpc.io/){target=\_blank} is a free and private RPC relay that protects user privacy by preventing data collection, user tracking, phishing attempts from other parties. It tunnels user requests via distributed relays to other RPC providers whilst preventing the tracking of user metadata such as IP address, device information and wallet linkability with secure enclave technology.
 
 1RPC is created to be an open initiative from the blockchain infrastructure community. They are motivated by a common good mission to help build a better Web3 and encourage anyone who values user privacy to join this open collaboration.
 
-Head over to [1RPC](https://www.1rpc.io){target=\_blank} official site to set it up!
+Head over to [1RPC](https://docs.1rpc.io/){target=\_blank} official site to set it up!
 
 ![1RPC](/images/builders/get-started/endpoints/endpoints-1.webp)
 


### PR DESCRIPTION
This PR updates the 1RPC URL in the endpoints documentation to point to their current documentation site. The original URL (https://www.1rpc.io) is no longer accessible, while the new URL (https://docs.1rpc.io) is active and provides users with the necessary documentation and access to the service.
