### PR TITLE
Polkadot.Network links migration to Polkadot.com

### DIFF
--- a/.snippets/text/node-operators/networks/collators/account-management/generate-session-keys.md
+++ b/.snippets/text/node-operators/networks/collators/account-management/generate-session-keys.md
@@ -1,4 +1,4 @@
-To match the Substrate standard, Moonbeam collator's session keys are [SR25519](https://wiki.polkadot.network/docs/learn-keys#what-is-sr25519-and-where-did-it-come-from){target=\_blank}. This guide will show you how you can create/rotate your session keys associated with your collator node.
+To match the Substrate standard, Moonbeam collator's session keys are [SR25519](https://wiki.polkadot.network/docs/learn-cryptography#what-is-sr25519-and-where-did-it-come-from){target=\_blank}. This guide will show you how you can create/rotate your session keys associated with your collator node.
 
 First, make sure you're [running a collator node](/node-operators/networks/run-a-node/overview/){target=\_blank}. Once you have your collator node running, your terminal should print similar logs:
 

--- a/builders/get-started/quick-start.md
+++ b/builders/get-started/quick-start.md
@@ -17,7 +17,7 @@ To get started developing on Moonbeam, it's important to be aware of the various
 
 |                                          Network                                          | Network Type  |                                   Relay Chain                                    | Native Asset Symbol | Native Asset Decimals |
 |:-----------------------------------------------------------------------------------------:|:-------------:|:--------------------------------------------------------------------------------:|:-------------------:|:---------------------:|
-|           [Moonbeam](/builders/get-started/networks/moonbeam/){target=\_blank}            |    MainNet    |               [Polkadot](https://polkadot.com){target=\_blank}               |        GLMR         |          18           |
+|           [Moonbeam](/builders/get-started/networks/moonbeam/){target=\_blank}            |    MainNet    |                 [Polkadot](https://polkadot.com){target=\_blank}                 |        GLMR         |          18           |
 |          [Moonriver](/builders/get-started/networks/moonriver/){target=\_blank}           |    MainNet    |                 [Kusama](https://kusama.network){target=\_blank}                 |        MOVR         |          18           |
 |        [Moonbase Alpha](/builders/get-started/networks/moonbase/){target=\_blank}         |    TestNet    | [Alphanet relay](/learn/platform/networks/moonbase/#relay-chain){target=\_blank} |         DEV         |          18           |
 | [Moonbeam Development Node](/builders/get-started/networks/moonbeam-dev/){target=\_blank} | Local TestNet |                                       None                                       |         DEV         |          18           |

--- a/builders/get-started/quick-start.md
+++ b/builders/get-started/quick-start.md
@@ -17,7 +17,7 @@ To get started developing on Moonbeam, it's important to be aware of the various
 
 |                                          Network                                          | Network Type  |                                   Relay Chain                                    | Native Asset Symbol | Native Asset Decimals |
 |:-----------------------------------------------------------------------------------------:|:-------------:|:--------------------------------------------------------------------------------:|:-------------------:|:---------------------:|
-|           [Moonbeam](/builders/get-started/networks/moonbeam/){target=\_blank}            |    MainNet    |               [Polkadot](https://polkadot.network){target=\_blank}               |        GLMR         |          18           |
+|           [Moonbeam](/builders/get-started/networks/moonbeam/){target=\_blank}            |    MainNet    |               [Polkadot](https://polkadot.com){target=\_blank}               |        GLMR         |          18           |
 |          [Moonriver](/builders/get-started/networks/moonriver/){target=\_blank}           |    MainNet    |                 [Kusama](https://kusama.network){target=\_blank}                 |        MOVR         |          18           |
 |        [Moonbase Alpha](/builders/get-started/networks/moonbase/){target=\_blank}         |    TestNet    | [Alphanet relay](/learn/platform/networks/moonbase/#relay-chain){target=\_blank} |         DEV         |          18           |
 | [Moonbeam Development Node](/builders/get-started/networks/moonbeam-dev/){target=\_blank} | Local TestNet |                                       None                                       |         DEV         |          18           |

--- a/learn/features/governance.md
+++ b/learn/features/governance.md
@@ -39,7 +39,7 @@ Some of the main components of this governance model include:
  - **Council & Technical Committee Governance V1** — a group of community members who have special voting rights within the system. With the deprecation and removal of Governance v1, both of these committees were dissolved as of the [runtime 2800 release](https://forum.moonbeam.network/t/runtime-rt2801-schedule/1616/4){target=\_blank}
  - **OpenGov Technical Committee** — a group of community members who can add certain proposals to the Whitelisted Track
 
-For more details on how these Substrate frame pallets implement on-chain governance, you can checkout the [Walkthrough of Polkadot’s Governance](https://polkadot.network/a-walkthrough-of-polkadots-governance){target=\_blank} blog post and the [Polkadot Governance Wiki](https://wiki.polkadot.network/docs/learn-polkadot-opengov){target=\_blank}.
+For more details on how these Substrate frame pallets implement on-chain governance, you can checkout the [Walkthrough of Polkadot’s Governance](https://polkadot.com/blog/a-walkthrough-of-polkadots-governance){target=\_blank} blog post and the [Polkadot Governance Wiki](https://wiki.polkadot.network/docs/learn-polkadot-opengov){target=\_blank}.
 
 ## Governance v2: OpenGov {: #opengov }
 

--- a/learn/platform/links.md
+++ b/learn/platform/links.md
@@ -6,7 +6,7 @@ description: If you're new to Moonbeam or the Polkadot network, here are some im
 # Links
 
  - **[Substrate Docs](https://docs.substrate.io){target=\_blank}** - starting point for learning about [Substrate](/learn/platform/glossary/#substrate){target=\_blank}, a Rust-based framework for developing blockchains. Moonbeam is developed using Substrate and uses many of the modules that come with it
- - **[Polkadot.network](https://polkadot.network){target=\_blank}** - learn about Polkadot, including the vision behind the network and how the system works, i.e., staking, governance, etc.
+ - **[Polkadot.com](https://polkadot.com){target=\_blank}** - learn about Polkadot, including the vision behind the network and how the system works, i.e., staking, governance, etc.
  - **[Polkadot-JS Apps](https://polkadot.js.org/apps){target=\_blank}** - a web-based interface for interacting with Substrate based nodes, including Moonbeam
  - **[Solidity Docs](https://solidity.readthedocs.io){target=\_blank}** - Solidity is the main smart contract programming language supported by Ethereum and Moonbeam.  The Solidity docs site is very comprehensive
  - **[Remix](https://remix.ethereum.org){target=\_blank}** - web-based IDE for Solidity smart contract development that is compatible with Moonbeam

--- a/learn/platform/networks/moonbase.md
+++ b/learn/platform/networks/moonbase.md
@@ -50,7 +50,7 @@ Some important variables/configurations to note include:
 
 ## Alphanet Relay Chain {: #relay-chain }
 
-The Alphanet relay chain is connected to Moonbase Alpha and is [Westend](https://polkadot.network/blog/westend-introducing-a-new-testnet-for-polkadot-and-kusama){target=\_blank}-based but unique to the Moonbeam ecosystem. It resembles how you would interact with Kusama or Polkadot. The native tokens of the Alphanet relay chain are UNIT tokens, which are for testing purposes only and have no real value.
+The Alphanet relay chain is connected to Moonbase Alpha and is [Westend](https://polkadot.com/blog/westend-introducing-a-new-testnet-for-polkadot-and-kusama){target=\_blank}-based but unique to the Moonbeam ecosystem. It resembles how you would interact with Kusama or Polkadot. The native tokens of the Alphanet relay chain are UNIT tokens, which are for testing purposes only and have no real value.
 
 ## Telemetry {: #telemetry }
 


### PR DESCRIPTION
### Description

Addresses links that were polkadot.network and should now be pointing to Polkadot.com. **note the polkadot wiki is not impacted by this change**

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
