### PR TITLE
Typo fix quick-start.md

### DIFF
--- a/builders/get-started/quick-start.md
+++ b/builders/get-started/quick-start.md
@@ -66,7 +66,7 @@ When working with developer tools, depending on the tool, you might need to conf
 
 ### Block Explorers {: #explorers }
 
-Moonbeam provides two different kind of explorers: ones to query the Ethereum API, and others dedicated to the Substrate API. All EVM-based transactions are accessible via the Ethereum API wheras the Substrate API can be relied upon for Substrate-native functions such as governance, staking, and some information about EVM-based transactions. For more information on each explorer, please check out the [Block Explorers](/builders/get-started/explorers/){target=\_blank} page.
+Moonbeam provides two different kind of explorers: ones to query the Ethereum API, and others dedicated to the Substrate API. All EVM-based transactions are accessible via the Ethereum API whereas the Substrate API can be relied upon for Substrate-native functions such as governance, staking, and some information about EVM-based transactions. For more information on each explorer, please check out the [Block Explorers](/builders/get-started/explorers/){target=\_blank} page.
 
 --8<-- 'text/builders/get-started/explorers/explorers.md'
 


### PR DESCRIPTION
# Pull Request Form

## Title of the Pull Request
Typo fix in `quick-start.md`

---

## Description
This pull request addresses a typo in the `quick-start.md` file:
- Corrected "wheras" to "whereas" in the Block Explorers section.
