### PR TITLE
Typos fix

### DIFF
--- a/builders/ethereum/precompiles/ux/batch.md
+++ b/builders/ethereum/precompiles/ux/batch.md
@@ -245,7 +245,7 @@ There will also be three values for the `value` array. The first address in the 
 ["1000000000000000000", "0", "0"]
 ```
 
-You will need three values for the `callData` array. Since transferring native currency does not require call data, the string is simply blank. The second and third values in the array correspond to invokations of **setMessage** that set messages to ids 5 and 6.
+You will need three values for the `callData` array. Since transferring native currency does not require call data, the string is simply blank. The second and third values in the array correspond to invocations of **setMessage** that set messages to ids 5 and 6.
 
 ```text
 [

--- a/builders/get-started/endpoints.md
+++ b/builders/get-started/endpoints.md
@@ -274,7 +274,7 @@ To override the balance of a particular account, you can override the account st
     // flags (u128): 170,141,183,460,469,231,731,687,303,715,884,105,728
     ```
 
-    Remember that the values are Little Endian encoded. To convert the Hexidecimal Little Endian encoded values to decimal, you can use [this converter](https://www.shawntabrizi.com/substrate-js-utilities/){target=_blank}, using the `Balance to Hex (Little Endian)` converter.
+    Remember that the values are Little Endian encoded. To convert the Hexadecimal Little Endian encoded values to decimal, you can use [this converter](https://www.shawntabrizi.com/substrate-js-utilities/){target=_blank}, using the `Balance to Hex (Little Endian)` converter.
 
     In this example, the existing free balance of `1,278,606,392,142,175,328,676` wei or approximately `1278.60` DEV is `a4d92a6a4e6b3a5045`. The following example will change the value to `500,000` DEV, which is `500,000,000,000,000,000,000,000` wei or `0x000080d07666e70de169` encoded as a hexidecimal Little Endian value. When properly padded to fit into the SCALE encoded storage value, it becomes `69e10de76676d08000000000000000000`, such that the table now looks like:
 

--- a/builders/interoperability/xcm/xc-registration/xc-integration.md
+++ b/builders/interoperability/xcm/xc-registration/xc-integration.md
@@ -120,7 +120,7 @@ An example of this process with a successful proposal on Moonbeam is depicted in
 
 ![Moonbeam and Moonriver cross-chain integration process](/images/builders/interoperability/xcm/xc-registration/xc-integration/channels-2.webp)
 
-Once these steps are succesfully completed, marketing efforts can be coordinated, and the new XC-20 on Moonriver/Moonbeam can be added to the **Cross Chain Assets** section of the [Moonbeam DApp](https://apps.moonbeam.network){target=\_blank}.
+Once these steps are successfully completed, marketing efforts can be coordinated, and the new XC-20 on Moonriver/Moonbeam can be added to the **Cross Chain Assets** section of the [Moonbeam DApp](https://apps.moonbeam.network){target=\_blank}.
 
 ### Create Forum Posts {: #create-forum-posts }
 

--- a/node-operators/networks/run-a-node/flags.md
+++ b/node-operators/networks/run-a-node/flags.md
@@ -52,7 +52,7 @@ This guide will cover some of the most common flags and show you how to access a
 ## Flags for Configuring a SQL Backend {: #flags-for-sql-backend }
 
 - **`--frontier-backend-type`** - sets the Frontier backend type to one of the following options:
-    - **`key-value`** - uses either RocksDB or ParityDB as per interited from the global backend settings. This is the default option and RocksDB is the default backend
+    - **`key-value`** - uses either RocksDB or ParityDB as per inherited from the global backend settings. This is the default option and RocksDB is the default backend
     - **`sql`** - uses a SQL database with custom log indexing
 - **`frontier-sql-backend-pool-size`** - sets the Frontier SQL backend's maximum number of database connections that a connection pool can simultaneously handle. The default is `100`
 - **`frontier-sql-backend-num-ops-timeout`** - sets the Frontier SQL backend's query timeout in number of VM operations. The default is `10000000`


### PR DESCRIPTION
### Changes

1. **File:** `/node-operators/networks/run-a-node/flags.md`
    - Fixed `interited` to `inherited` (Line 55)
1. **File:** `/builders/interoperability/xcm/xc-registration/xc-integration.md`
    - Fixed `succesfully` to `successfully` (Line 123)
1. **File:** `/builders/get-started/endpoints.md`
    - Fixed `Hexidecimal` to `Hexadecimal` (Line 277)
1. **File:** `/builders/ethereum/precompiles/ux/batch.md`
    - Fixed `invokations` to `invocations` (Line 248)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.