### PR TITLE
Moonbeam Runtime 3600 - Modify Min Collator Self Stake

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -1051,8 +1051,8 @@ networks:
       collator_reward_inflation: 20
       parachain_bond_inflation: 30
     staking:
-      min_can_stk: 2000000
-      min_can_stk_wei: 2000000000000000000000000
+      min_can_stk: 500000
+      min_can_stk_wei: 500000000000000000000000
       collator_map_bond: 10000
       max_candidates: 76
       round_blocks: 1800


### PR DESCRIPTION
### Description

Modifies the Moonbeam collator self stake from 2,000,000 GLMR to 500,000 GLMR. Moonriver not changing. This should be merged according to the timeline of Runtime 3600 Schedule:

https://forum.moonbeam.network/t/runtime-rt3600-schedule/2071

May 4th - Moonbeam Scheduled Release of RT3600

### Checklist

- [x] I have added a label to this PR 🏷️

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
