### PR TITLE
Document bug fix for weight limits in EVM tracing runtimes

### DIFF
--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -335,6 +335,24 @@ You can review the [relative Frontier PR](https://github.com/polkadot-evm/fronti
 
 ---
 
+#### EVM Tracing Weight Limits {: #evm-tracing-weight-limits }
+
+Runtimes with the `evm-tracing` feature enabled introduced additional `ref_time` overhead due to special logic that traces Ethereum transactions (emitting events for each component: gasometer, runtime, EVM) used to fill information for RPC calls like `debug_traceTransaction` and `trace_filter`. 
+
+Since the real `ref_time` in production runtimes is smaller, this could cause the block weight limits to be reached when replaying a block in an EVM-tracing runtime, resulting in skipped transaction traces. This was observed in Moonbeam block [9770044](https://moonbeam.subscan.io/block/9770044){target=\_blank}.
+
+The fix consisted of resetting the previously consumed weight before tracing each Ethereum transaction. It's important to note that this issue only affected code under `evm-tracing`, which is not included in any production runtime.
+
+This bug was fixed in the following runtime:
+
+|    Network     | Fixed  | Impacted Block |
+|:--------------:|:------:|:--------------:|
+|    Moonbeam    | RT3501 |    9770044     |
+
+For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/3210){target=\_blank}.
+
+---
+
 ## Migrations {: #migrations }
 
 Migrations are necessary when a storage item is changed or added and needs to be populated with data. The migrations listed below have been organized by the impacted pallet(s).
@@ -840,7 +858,6 @@ This migration was executed at the following runtimes and blocks:
 | Moonbase Alpha |      RT2801      |    6209638    |
 
 For more information, you can review the [relative PR on GitHub](https://github.com/moonbeam-foundation/moonbeam/pull/2634){target=\_blank}.
-
 
 ---
 

--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -335,7 +335,7 @@ You can review the [relative Frontier PR](https://github.com/polkadot-evm/fronti
 
 ---
 
-#### EVM Tracing Weight Limits {: #evm-tracing-weight-limits }
+#### Skipped Ethereum Transaction Traces {: #skipped-ethereum-transaction-traces }
 
 Runtimes with the `evm-tracing` feature enabled introduced additional `ref_time` overhead due to special logic that traces Ethereum transactions (emitting events for each component: gasometer, runtime, EVM) used to fill information for RPC calls like `debug_traceTransaction` and `trace_filter`. 
 


### PR DESCRIPTION
### Description
Document bug fix for weight limits in EVM tracing runtimes, which fixes an issue where EVM tracing runtimes could hit block weight limits when replaying blocks, causing skipped transaction traces, by resetting the consumed weight before tracing each Ethereum transaction.

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
