### PR TITLE
Identity Proxy 

### DIFF
--- a/builders/substrate/interfaces/account/identity.md
+++ b/builders/substrate/interfaces/account/identity.md
@@ -31,7 +31,7 @@ The Identity Pallet provides the following extrinsics (functions):
         --8<-- 'code/builders/substrate/interfaces/account/identity/add-registrar.js'
         ```
 
-??? function "**addSub**(sub, data) - adds an account as a sub-account of the caller. You can optionally provide a name for the sub-account"
+??? function "**addSub**(sub, data) - adds an account as a sub-account of the caller. You can optionally provide a name for the sub-account. This function is not callable via a `NonTransfer` proxy. You can sign the transaction directly or use a different proxy type (`Any`, `IdentityJudgement`, etc.)" 
 
     === "Parameters"
 
@@ -233,7 +233,7 @@ The Identity Pallet provides the following extrinsics (functions):
         --8<-- 'code/builders/substrate/interfaces/account/identity/set-identity.js'
         ```
 
-??? function "**setSubs**(subs) - sets the sub-accounts for the caller"
+??? function "**setSubs**(subs) - sets the sub-accounts for the caller. This function is not callable via a `NonTransfer` proxy. You can sign the transaction directly or use a different proxy type (`Any`, `IdentityJudgement`, etc.)"
 
     === "Parameters"
 


### PR DESCRIPTION
### Description

Identity calls `add_sub and set_subs` are no longer callable from a `NonTransfer` proxy.

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
