### PR TITLE
Blast Deprecate Moonriver Moonbase Alpha

### DIFF
--- a/.snippets/text/builders/get-started/endpoints/moonbase.md
+++ b/.snippets/text/builders/get-started/endpoints/moonbase.md
@@ -1,7 +1,6 @@
 === "HTTPS"
     |      Provider       |                              RPC URL                               |   Limits    |
     |:-------------------:|:------------------------------------------------------------------:|:-----------:|
-    |        Blast        |     <pre>```https://moonbase-alpha.public.blastapi.io```</pre>     | 80 req/sec  |
     |       Dwellir       |         <pre>```https://moonbase-rpc.dwellir.com```</pre>          | 20 req/sec  |
     |     OnFinality      |  <pre>```https://moonbeam-alpha.api.onfinality.io/public```</pre>  | 40 req/sec  |
     | Moonbeam Foundation |     <pre>```https://rpc.api.moonbase.moonbeam.network```</pre>     | 25 req/sec  |
@@ -11,7 +10,6 @@
 === "WSS"
     |      Provider       |                              RPC URL                              |   Limits    |
     |:-------------------:|:-----------------------------------------------------------------:|:-----------:|
-    |        Blast        |     <pre>```wss://moonbase-alpha.public.blastapi.io```</pre>      | 80 req/sec  |
     |       Dwellir       |          <pre>```wss://moonbase-rpc.dwellir.com```</pre>          | 20 req/sec  |
     |     OnFinality      | <pre>```wss://moonbeam-alpha.api.onfinality.io/public-ws```</pre> | 40 req/sec  |
     | Moonbeam Foundation |     <pre>```wss://wss.api.moonbase.moonbeam.network```</pre>      | 25 req/sec  |

--- a/.snippets/text/builders/get-started/endpoints/moonriver.md
+++ b/.snippets/text/builders/get-started/endpoints/moonriver.md
@@ -1,7 +1,6 @@
 === "HTTPS"
       |  Provider   |                               RPC URL                               |   Limits    |
       |:-----------:|:-------------------------------------------------------------------:|:-----------:|
-      |    Blast    |        <pre>```https://moonriver.public.blastapi.io```</pre>        | 80 req/sec  |
       |   Dwellir   |         <pre>```https://moonriver-rpc.dwellir.com```</pre>          | 20 req/sec  |
       | OnFinality  |     <pre>```https://moonriver.api.onfinality.io/public```</pre>     | 40 req/sec  |
       | UnitedBloc  |          <pre>```https://moonriver.unitedbloc.com```</pre>          | 32 req/sec  |
@@ -10,7 +9,6 @@
 === "WSS"
     |  Provider   |                             RPC URL                             |   Limits    |
     |:-----------:|:---------------------------------------------------------------:|:-----------:|
-    |    Blast    |       <pre>```wss://moonriver.public.blastapi.io```</pre>       | 80 req/sec  |
     |   Dwellir   |        <pre>```wss://moonriver-rpc.dwellir.com```</pre>         | 20 req/sec  |
     | OnFinality  |  <pre>```wss://moonriver.api.onfinality.io/public-ws```</pre>   | 40 req/sec  |
     | UnitedBloc  |         <pre>```wss://moonriver.unitedbloc.com```</pre>         | 32 req/sec  |

--- a/builders/get-started/endpoints.md
+++ b/builders/get-started/endpoints.md
@@ -56,9 +56,9 @@ To get started, you'll need to head to [Blast](https://blastapi.io){target=_blan
 
 1. Create a new project
 2. Click on **Available Endpoints**
-3. Select a network for your endpoint. There are three options to choose from: Moonbeam, Moonriver and Moonbase Alpha
+3. Select Moonbeam network for your endpoint
 4. Confirm the selected network and Press **Activate**
-5. You'll now see your chosen network under **Active Endpoints**. Click on the network and you'll see your custom RPC and WSS endpoints on the next page
+5. You'll now see Moonbeam under **Active Endpoints**. Click on the network and you'll see your custom RPC and WSS endpoints on the next page
 
 ![Bware Labs](/images/builders/get-started/endpoints/endpoints-2.webp)
 


### PR DESCRIPTION
### Description

Blast has Deprecated Moonriver Moonbase Alpha endpoints. Moonbeam is still supported. 

### Checklist

- [x] I have added a label to this PR 🏷️

