### PR TITLE
Removed StorageCleaner precompile

### DIFF
--- a/.snippets/text/builders/ethereum/canonical-contracts/non-specific.md
+++ b/.snippets/text/builders/ethereum/canonical-contracts/non-specific.md
@@ -20,4 +20,3 @@
     |                          [SHA3FIPS256](/builders/ethereum/precompiles/utility/eth-mainnet/#hashing-with-sha3fips256){target=\_blank}                          | 0x0000000000000000000000000000000000000400 |
     |                                                                      Dispatch [Removed]                                                                       | 0x0000000000000000000000000000000000000401 |
     |      [ECRecoverPublicKey](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_simple/struct.ECRecoverPublicKey.html){target=\_blank}       | 0x0000000000000000000000000000000000000402 |
-    | [StorageCleaner](https://polkadot-evm.github.io/frontier/rustdocs/pallet_evm_precompile_storage_cleaner/struct.StorageCleanerPrecompile.html){target=\_blank} | 0x0000000000000000000000000000000000000403 |

--- a/builders/ethereum/precompiles/utility/non-specific.md
+++ b/builders/ethereum/precompiles/utility/non-specific.md
@@ -1,7 +1,7 @@
 ---
 title: Non-Network Specific Precompiles
 description: Learn how to use precompiled contracts, which are not specific to Ethereum or Moonbeam, yet are supported for use in your application.
-keywords: ethereum, moonbeam, StorageCleaner, ECRecoverPublicKey, sha3FIPS256
+keywords: ethereum, moonbeam, ECRecoverPublicKey, sha3FIPS256
 ---
 
 # Non-Network Specific Precompiled Smart Contracts
@@ -12,15 +12,9 @@ A precompiled contract, or precompile, is a set of programmed functionalities ha
 
 Precompile functionality is bundled and shared under a smart contract address, which allows interactions similar to those of a traditional smart contract. Some precompiled contracts are not specific to Ethereum or Moonbeam, but are supported for use in your Moonbeam application. 
 
-The nonspecific precompiles currently included in this category include `StorageCleaner`, `ECRecoverPublicKey`, and `SHA3FIPS256`. 
+The nonspecific precompiles currently included in this category are the `ECRecoverPublicKey` and `SHA3FIPS256` precompiles. 
 
 In the next section, you will learn more about the functionalities included in these precompiles.  
-
-## Clear Storage Entries with StorageCleaner {: #clear-storage-with-storagecleaner }
-
-The primary function of the `StorageCleaner` precompile is to clear storage entry key-value pairs for a smart contract marked as self-destructed, previously referred to as 'suicided.' `StorageCleaner` includes functionality to iterate over a list of addresses to identify self-destructed contracts and delete the appropriate storage entries associated with identified addresses. You can also input a numeric limit to prevent the precompile from consuming too much gas. 
-
-With the implementation of [EIP-6780: SELFDESTRUCT](https://eips.ethereum.org/EIPS/eip-6780){target=\_blank} as part of the Ethereum Cancun/Dencun upgrade, contracts can only be self-destructed in the same transaction where they are created. This limitation keeps storage entries small and allows them to be automatically deleted during destruction. The `StorageCleaner` precompile remains available when a legacy contract needs storage entries cleared. 
 
 ## Retrieve a Public Key with ECRecoverPublicKey {: verifying-signatures-ecrecoverpublickey }
 


### PR DESCRIPTION
### Description

Removed StorageCleaner precompile from the non-specific.md page, as per this PR: https://github.com/moonbeam-foundation/moonbeam/pull/3224

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
