### PR TITLE
add url to link checker config

### DIFF
--- a/.github/workflows/pr-link-checker.yml
+++ b/.github/workflows/pr-link-checker.yml
@@ -12,5 +12,6 @@ jobs:
       docs_repo: moonbeam-foundation/moonbeam-docs
       mkdocs_repo_name: moonbeam-mkdocs
       docs_repo_name: moonbeam-docs
+      url: https://docs.moonbeam.network
     secrets:
       GH_TOKEN: ${{ secrets.GH_PR_404_CHECKER }}


### PR DESCRIPTION
### Description

This pull request includes a small change to the `.github/workflows/pr-link-checker.yml` file. The change adds a new `url` parameter to the `jobs:` section, specifying the Moonbeam documentation URL.

This is used to convert markdown file paths to URLs, which can then be excluded from the link checker workflow.

### Checklist

- [ ] I have added a label to this PR 🏷️

Goes with PR: https://github.com/papermoonio/workflows/pull/2/files