### PR TITLE
Clarify Apple Silicon Instructions 

### DIFF
--- a/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-pull.md
+++ b/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-pull.md
@@ -1,7 +1,7 @@
 <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -10,7 +10,7 @@
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>

--- a/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-run.md
+++ b/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-run.md
@@ -1,6 +1,6 @@
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/builders/get-started/networks/moonbeam-dev.md
+++ b/builders/get-started/networks/moonbeam-dev.md
@@ -64,7 +64,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/builders/get-started/networks/moonbeam-dev.md
+++ b/builders/get-started/networks/moonbeam-dev.md
@@ -63,8 +63,20 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-basics.txt
+++ b/llms-files/llms-basics.txt
@@ -4327,7 +4327,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-basics.txt
+++ b/llms-files/llms-basics.txt
@@ -4272,9 +4272,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -4283,8 +4283,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -4314,14 +4314,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-basics.txt
+++ b/llms-files/llms-basics.txt
@@ -4315,7 +4315,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-dev-environments.txt
+++ b/llms-files/llms-dev-environments.txt
@@ -10713,9 +10713,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -10724,8 +10724,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -10755,14 +10755,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-dev-environments.txt
+++ b/llms-files/llms-dev-environments.txt
@@ -10768,7 +10768,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-dev-environments.txt
+++ b/llms-files/llms-dev-environments.txt
@@ -10756,7 +10756,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-ethereum-toolkit.txt
+++ b/llms-files/llms-ethereum-toolkit.txt
@@ -25942,7 +25942,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-ethereum-toolkit.txt
+++ b/llms-files/llms-ethereum-toolkit.txt
@@ -25887,9 +25887,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -25898,8 +25898,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -25929,14 +25929,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-ethereum-toolkit.txt
+++ b/llms-files/llms-ethereum-toolkit.txt
@@ -25930,7 +25930,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-gmp-providers.txt
+++ b/llms-files/llms-gmp-providers.txt
@@ -5384,7 +5384,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-gmp-providers.txt
+++ b/llms-files/llms-gmp-providers.txt
@@ -5396,7 +5396,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-gmp-providers.txt
+++ b/llms-files/llms-gmp-providers.txt
@@ -5341,9 +5341,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -5352,8 +5352,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -5383,14 +5383,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-governance.txt
+++ b/llms-files/llms-governance.txt
@@ -5095,7 +5095,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-governance.txt
+++ b/llms-files/llms-governance.txt
@@ -5040,9 +5040,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -5051,8 +5051,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -5082,14 +5082,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-governance.txt
+++ b/llms-files/llms-governance.txt
@@ -5083,7 +5083,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-indexers-and-queries.txt
+++ b/llms-files/llms-indexers-and-queries.txt
@@ -6849,7 +6849,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-indexers-and-queries.txt
+++ b/llms-files/llms-indexers-and-queries.txt
@@ -6837,7 +6837,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-indexers-and-queries.txt
+++ b/llms-files/llms-indexers-and-queries.txt
@@ -6794,9 +6794,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -6805,8 +6805,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -6836,14 +6836,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-integrations.txt
+++ b/llms-files/llms-integrations.txt
@@ -4978,7 +4978,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-integrations.txt
+++ b/llms-files/llms-integrations.txt
@@ -4923,9 +4923,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -4934,8 +4934,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -4965,14 +4965,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-integrations.txt
+++ b/llms-files/llms-integrations.txt
@@ -4966,7 +4966,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-json-rpc-apis.txt
+++ b/llms-files/llms-json-rpc-apis.txt
@@ -5768,9 +5768,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -5779,8 +5779,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -5810,14 +5810,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-json-rpc-apis.txt
+++ b/llms-files/llms-json-rpc-apis.txt
@@ -5811,7 +5811,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-json-rpc-apis.txt
+++ b/llms-files/llms-json-rpc-apis.txt
@@ -5823,7 +5823,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-libraries-and-sdks.txt
+++ b/llms-files/llms-libraries-and-sdks.txt
@@ -10285,9 +10285,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -10296,8 +10296,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -10327,14 +10327,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-libraries-and-sdks.txt
+++ b/llms-files/llms-libraries-and-sdks.txt
@@ -10328,7 +10328,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-libraries-and-sdks.txt
+++ b/llms-files/llms-libraries-and-sdks.txt
@@ -10340,7 +10340,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-node-operators-and-collators.txt
+++ b/llms-files/llms-node-operators-and-collators.txt
@@ -7635,9 +7635,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -7646,8 +7646,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -7677,14 +7677,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-node-operators-and-collators.txt
+++ b/llms-files/llms-node-operators-and-collators.txt
@@ -1467,6 +1467,17 @@ Note that in the following start-up command, you have to:
 
 For an overview of the flags used in the following start-up commands, plus additional commonly used flags, please refer to the [Flags](/node-operators/networks/run-a-node/flags/){target=\_blank} page of our documentation.
 
+!!! note "For Apple Silicon users"
+    If Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands. For example:
+
+    ```bash
+    docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }}
+    ```
+
+    ```bash
+    docker run --platform=linux/amd64 ...
+    ```
+
 ### Full Node {: #full-node }
 
 ???+ code "Linux snippets"

--- a/llms-files/llms-node-operators-and-collators.txt
+++ b/llms-files/llms-node-operators-and-collators.txt
@@ -1468,7 +1468,7 @@ Note that in the following start-up command, you have to:
 For an overview of the flags used in the following start-up commands, plus additional commonly used flags, please refer to the [Flags](/node-operators/networks/run-a-node/flags/){target=\_blank} page of our documentation.
 
 !!! note "For Apple Silicon users"
-    If Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands. For example:
+    If Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands. For example:
 
     ```bash
     docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }}
@@ -7689,7 +7689,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-node-operators-and-collators.txt
+++ b/llms-files/llms-node-operators-and-collators.txt
@@ -7701,7 +7701,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-oracle-nodes.txt
+++ b/llms-files/llms-oracle-nodes.txt
@@ -5354,7 +5354,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-oracle-nodes.txt
+++ b/llms-files/llms-oracle-nodes.txt
@@ -5342,7 +5342,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-oracle-nodes.txt
+++ b/llms-files/llms-oracle-nodes.txt
@@ -5299,9 +5299,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -5310,8 +5310,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -5341,14 +5341,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-precompiles.txt
+++ b/llms-files/llms-precompiles.txt
@@ -15763,7 +15763,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-precompiles.txt
+++ b/llms-files/llms-precompiles.txt
@@ -15775,7 +15775,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-precompiles.txt
+++ b/llms-files/llms-precompiles.txt
@@ -15720,9 +15720,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -15731,8 +15731,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -15762,14 +15762,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-staking.txt
+++ b/llms-files/llms-staking.txt
@@ -10558,7 +10558,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-staking.txt
+++ b/llms-files/llms-staking.txt
@@ -10503,9 +10503,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -10514,8 +10514,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -10545,14 +10545,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-staking.txt
+++ b/llms-files/llms-staking.txt
@@ -10546,7 +10546,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-substrate-toolkit.txt
+++ b/llms-files/llms-substrate-toolkit.txt
@@ -17822,7 +17822,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-substrate-toolkit.txt
+++ b/llms-files/llms-substrate-toolkit.txt
@@ -17834,7 +17834,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-substrate-toolkit.txt
+++ b/llms-files/llms-substrate-toolkit.txt
@@ -17779,9 +17779,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -17790,8 +17790,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -17821,14 +17821,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-tokens-and-accounts.txt
+++ b/llms-files/llms-tokens-and-accounts.txt
@@ -8700,7 +8700,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-tokens-and-accounts.txt
+++ b/llms-files/llms-tokens-and-accounts.txt
@@ -8688,7 +8688,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-tokens-and-accounts.txt
+++ b/llms-files/llms-tokens-and-accounts.txt
@@ -8645,9 +8645,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -8656,8 +8656,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -8687,14 +8687,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-tutorials.txt
+++ b/llms-files/llms-tutorials.txt
@@ -18722,7 +18722,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-tutorials.txt
+++ b/llms-files/llms-tutorials.txt
@@ -18679,9 +18679,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -18690,8 +18690,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -18721,14 +18721,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-tutorials.txt
+++ b/llms-files/llms-tutorials.txt
@@ -18734,7 +18734,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-xc-20.txt
+++ b/llms-files/llms-xc-20.txt
@@ -7186,7 +7186,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-xc-20.txt
+++ b/llms-files/llms-xc-20.txt
@@ -7198,7 +7198,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-xc-20.txt
+++ b/llms-files/llms-xc-20.txt
@@ -7143,9 +7143,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -7154,8 +7154,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -7185,14 +7185,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-xcm-remote-execution.txt
+++ b/llms-files/llms-xcm-remote-execution.txt
@@ -7624,9 +7624,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -7635,8 +7635,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -7666,14 +7666,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-xcm-remote-execution.txt
+++ b/llms-files/llms-xcm-remote-execution.txt
@@ -7679,7 +7679,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-xcm-remote-execution.txt
+++ b/llms-files/llms-xcm-remote-execution.txt
@@ -7667,7 +7667,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-xcm.txt
+++ b/llms-files/llms-xcm.txt
@@ -9762,7 +9762,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+        If performance is still insufficient, consider [spinning up a node with a binary file](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 

--- a/llms-files/llms-xcm.txt
+++ b/llms-files/llms-xcm.txt
@@ -9750,7 +9750,7 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         ```
 
     !!! note "For Apple Silicon users"
-        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
 
         ```bash
         docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}

--- a/llms-files/llms-xcm.txt
+++ b/llms-files/llms-xcm.txt
@@ -9707,9 +9707,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.46.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.46.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -9718,8 +9718,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.46.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.46.0
   </span>
 </div>
 
@@ -9749,14 +9749,26 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
         --dev --rpc-external
         ```
 
-!!! note
-    On MacOS with silicon chips, Docker images may perform poorly. To improve performance, try [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
+    !!! note "For Apple Silicon users"
+        If the Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands:
+
+        ```bash
+        docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.development.build_tag }}
+        ```
+
+        ```bash
+        docker run --rm --platform=linux/amd64 --name {{ networks.development.container_name }} -p 9944:9944 \
+        moonbeamfoundation/moonbeam:{{ networks.development.build_tag }} \
+        --dev --rpc-external
+        ```
+
+        If performance is still insufficient, consider [spinning up a Node with a Binary File](#getting-started-with-the-binary-file).
 
 If successful, you should see an output showing an idle state waiting for blocks to be authored:
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.46.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/node-operators/networks/run-a-node/docker.md
+++ b/node-operators/networks/run-a-node/docker.md
@@ -86,6 +86,17 @@ Note that in the following start-up command, you have to:
 
 For an overview of the flags used in the following start-up commands, plus additional commonly used flags, please refer to the [Flags](/node-operators/networks/run-a-node/flags/){target=\_blank} page of our documentation.
 
+!!! note "For Apple Silicon users"
+    If Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands. For example:
+
+    ```bash
+    docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }}
+    ```
+
+    ```bash
+    docker run --platform=linux/amd64 ...
+    ```
+
 ### Full Node {: #full-node }
 
 ???+ code "Linux snippets"

--- a/node-operators/networks/run-a-node/docker.md
+++ b/node-operators/networks/run-a-node/docker.md
@@ -87,7 +87,7 @@ Note that in the following start-up command, you have to:
 For an overview of the flags used in the following start-up commands, plus additional commonly used flags, please refer to the [Flags](/node-operators/networks/run-a-node/flags/){target=\_blank} page of our documentation.
 
 !!! note "For Apple Silicon users"
-    If Docker commands fail or behave unexpectedly on Apple Silicon, enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in Docker Desktop settings and use the `amd64` platform for both pull and run commands. For example:
+    If Docker commands fail or behave unexpectedly on Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in Docker Desktop settings and use the `amd64` platform for both pull and run commands. For example:
 
     ```bash
     docker pull --platform=linux/amd64 moonbeamfoundation/moonbeam:{{ networks.moonbeam.parachain_release_tag }}


### PR DESCRIPTION
### Description

Clarify Apple Silicon Instructions for Docker Node running. 

This pull request updates the documentation and code snippets to use the latest `moonbeamfoundation/moonbeam` Docker image version (`v0.46.0`) and improves guidance for Apple Silicon users. The changes ensure consistency across multiple files and provide clearer instructions for running Moonbeam nodes on Apple Silicon devices.

Moonbeam Docker image version updates:

* Updated all references and code snippets to use `moonbeamfoundation/moonbeam:v0.46.0` instead of previous versions (`v0.43.0` and `v0.45.0`) in `.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-pull.md`, `.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-run.md`, and multiple `llms-files` documentation files. [[1]](diffhunk://#diff-6658df7e8a542f9c645300b6b5399ffef6b909856c5f38a71ad715f6666399afL2-R4) [[2]](diffhunk://#diff-eb19d8433782c9d4ee07442cae39ca6b945529ba231b32e76a1748f0dde1edfdL3-R3) [[3]](diffhunk://#diff-6d86b9f05272950ce32743b170bb3b29ca78ffa07092054b92afd703ddf156e6L4275-R4277) [[4]](diffhunk://#diff-6d86b9f05272950ce32743b170bb3b29ca78ffa07092054b92afd703ddf156e6L4286-R4287) [[5]](diffhunk://#diff-6d86b9f05272950ce32743b170bb3b29ca78ffa07092054b92afd703ddf156e6L4317-R4336) [[6]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL10716-R10718) [[7]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL10727-R10728) [[8]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL10758-R10777) [[9]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206L25890-R25892) [[10]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206L25901-R25902) [[11]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206L25932-R25951) [[12]](diffhunk://#diff-19c9d4f23cc0fab01e2f310a9e6f87055fd7c7a573f2362bfcb9ea50556b3154L5344-R5346) [[13]](diffhunk://#diff-19c9d4f23cc0fab01e2f310a9e6f87055fd7c7a573f2362bfcb9ea50556b3154L5355-R5356) [[14]](diffhunk://#diff-19c9d4f23cc0fab01e2f310a9e6f87055fd7c7a573f2362bfcb9ea50556b3154L5386-R5405) [[15]](diffhunk://#diff-175e47e31d26a19d2b696b1ce853767a65d6edf2e25272c5af80c5c6f89c47faL5043-R5045) [[16]](diffhunk://#diff-175e47e31d26a19d2b696b1ce853767a65d6edf2e25272c5af80c5c6f89c47faL5054-R5055) [[17]](diffhunk://#diff-175e47e31d26a19d2b696b1ce853767a65d6edf2e25272c5af80c5c6f89c47faL5085-R5104) [[18]](diffhunk://#diff-47a2d2044b87459f9ac7f92f6e999b2f578044c372107befb95826b4a44ff953L6797-R6799) [[19]](diffhunk://#diff-47a2d2044b87459f9ac7f92f6e999b2f578044c372107befb95826b4a44ff953L6808-R6809)

Apple Silicon compatibility improvements:

* Replaced the previous performance note for MacOS with a more detailed section for Apple Silicon users, advising to enable Rosetta emulation and use the `amd64` platform for Docker commands. This guidance is included in both `builders/get-started/networks/moonbeam-dev.md` and all relevant `llms-files` documentation files. [[1]](diffhunk://#diff-4700eb9c57685dc76973902624974a894259e49a4bd2930fd3d9493e19b91ca3L66-R79) [[2]](diffhunk://#diff-6d86b9f05272950ce32743b170bb3b29ca78ffa07092054b92afd703ddf156e6L4317-R4336) [[3]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL10758-R10777) [[4]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206L25932-R25951) [[5]](diffhunk://#diff-19c9d4f23cc0fab01e2f310a9e6f87055fd7c7a573f2362bfcb9ea50556b3154L5386-R5405) [[6]](diffhunk://#diff-175e47e31d26a19d2b696b1ce853767a65d6edf2e25272c5af80c5c6f89c47faL5085-R5104)

Consistency and clarity in documentation:

* Ensured all code and output snippets reflect the updated Docker image version and improved instructions, providing a consistent experience for users across different environments and documentation sections. (All references above) 

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
