### PR TITLE
Client Version 47 Updates

### DIFF
--- a/.snippets/code/builders/ethereum/json-rpc/debug-trace/terminal/start-up-logs.md
+++ b/.snippets/code/builders/ethereum/json-rpc/debug-trace/terminal/start-up-logs.md
@@ -1,7 +1,7 @@
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --network host  \
     <br>-u $(id -u ${USER}):$(id -g ${USER}) \
-        moonbeamfoundation/moonbeam-tracing:v0.45.0-3701-a160 \
+        moonbeamfoundation/moonbeam-tracing:v0.47.0-3900-b897 \
     <br>--name="Moonbean-Tracing-Tutorial" \
     <br>--unsafe-rpc-external \
     <br>--ethapi=debug,trace,txpool \

--- a/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-pull.md
+++ b/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-pull.md
@@ -1,7 +1,7 @@
 <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -10,7 +10,7 @@
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>

--- a/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-run.md
+++ b/.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-run.md
@@ -1,6 +1,6 @@
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/.snippets/code/node-operators/networks/run-a-node/docker/terminal/start.md
+++ b/.snippets/code/node-operators/networks/run-a-node/docker/terminal/start.md
@@ -1,5 +1,5 @@
 <div id="termynal" data-termynal>
-     <span data-ty="input"><span class="file-path"></span>docker run --network="host" -v "/var/lib/alphanet-data:/d ata" -u $(id-u ${USER}):$(id -g #{USER}) moonbeam-foundation/moonbeam:v0.45.0 --base-path=/d ata --chain alphanet --name="TestNode" --state-pruning archive --trie-cache-size 1073741824 --db-cache 8000 ----name="TestNode (Embedded Relay)"</span>
+     <span data-ty="input"><span class="file-path"></span>docker run --network="host" -v "/var/lib/alphanet-data:/d ata" -u $(id-u ${USER}):$(id -g #{USER}) moonbeam-foundation/moonbeam:v0.47.0 --base-path=/d ata --chain alphanet --name="TestNode" --state-pruning archive --trie-cache-size 1073741824 --db-cache 8000 ----name="TestNode (Embedded Relay)"</span>
     <span data-ty>2025-07-10 09:04:26 Moonbeam Parachain Collator </span>
     <span data-ty>2025-07-10 09:04:26 ✌️  version 0.46.0-d7df89e7161 </span>
     <span data-ty>2025-07-10 09:04:26 ❤️  by PureStake, 2019-2025 </span>

--- a/.snippets/code/tutorials/integrations/local-subsquid/terminal/start-node.md
+++ b/.snippets/code/tutorials/integrations/local-subsquid/terminal/start-node.md
@@ -1,6 +1,6 @@
 <div id="termynal" data-termynal>
     <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development -p 9944:9944 \</span>
-    <span data-ty>moonbeamfoundation/moonbeam:v0.45.0 \</span>
+    <span data-ty>moonbeamfoundation/moonbeam:v0.47.0 \</span>
     <span data-ty>--dev --rpc-external</span>
     <span data-ty>2025-07-10 09:04:26 Moonbeam Parachain Collator</span>
     <span data-ty>2025-07-10 09:04:26 ✌️  version 0.46.0-d7df89e7161</span>

--- a/llms-files/llms-basics.txt
+++ b/llms-files/llms-basics.txt
@@ -4272,9 +4272,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -4283,8 +4283,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -4321,7 +4321,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-dev-environments.txt
+++ b/llms-files/llms-dev-environments.txt
@@ -10713,9 +10713,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -10724,8 +10724,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -10762,7 +10762,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-ethereum-toolkit.txt
+++ b/llms-files/llms-ethereum-toolkit.txt
@@ -4346,7 +4346,7 @@ If you wish to set up your own tracing node, you can follow the [Running a Traci
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --network host  \
     <br>-u $(id -u ${USER}):$(id -g ${USER}) \
-        moonbeamfoundation/moonbeam-tracing:v0.45.0-3701-a160 \
+        moonbeamfoundation/moonbeam-tracing:v0.47.0-3900-b897 \
     <br>--name="Moonbean-Tracing-Tutorial" \
     <br>--unsafe-rpc-external \
     <br>--ethapi=debug,trace,txpool \
@@ -25887,9 +25887,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -25898,8 +25898,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -25936,7 +25936,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-gmp-providers.txt
+++ b/llms-files/llms-gmp-providers.txt
@@ -5341,9 +5341,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -5352,8 +5352,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -5390,7 +5390,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-governance.txt
+++ b/llms-files/llms-governance.txt
@@ -5040,9 +5040,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -5051,8 +5051,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -5089,7 +5089,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-indexers-and-queries.txt
+++ b/llms-files/llms-indexers-and-queries.txt
@@ -6794,9 +6794,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -6805,8 +6805,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -6843,7 +6843,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-integrations.txt
+++ b/llms-files/llms-integrations.txt
@@ -4923,9 +4923,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -4934,8 +4934,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -4972,7 +4972,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-json-rpc-apis.txt
+++ b/llms-files/llms-json-rpc-apis.txt
@@ -44,7 +44,7 @@ If you wish to set up your own tracing node, you can follow the [Running a Traci
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --network host  \
     <br>-u $(id -u ${USER}):$(id -g ${USER}) \
-        moonbeamfoundation/moonbeam-tracing:v0.45.0-3701-a160 \
+        moonbeamfoundation/moonbeam-tracing:v0.47.0-3900-b897 \
     <br>--name="Moonbean-Tracing-Tutorial" \
     <br>--unsafe-rpc-external \
     <br>--ethapi=debug,trace,txpool \
@@ -5768,9 +5768,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -5779,8 +5779,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -5817,7 +5817,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-libraries-and-sdks.txt
+++ b/llms-files/llms-libraries-and-sdks.txt
@@ -10285,9 +10285,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -10296,8 +10296,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -10334,7 +10334,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-node-operators-and-collators.txt
+++ b/llms-files/llms-node-operators-and-collators.txt
@@ -1808,7 +1808,7 @@ Now you can run your Docker start up commands:
 Once Docker pulls the necessary images, your full node will start, displaying lots of information, such as the chain specification, node name, role, genesis state, and more.
 
 <div id="termynal" data-termynal>
-     <span data-ty="input"><span class="file-path"></span>docker run --network="host" -v "/var/lib/alphanet-data:/d ata" -u $(id-u ${USER}):$(id -g #{USER}) moonbeam-foundation/moonbeam:v0.45.0 --base-path=/d ata --chain alphanet --name="TestNode" --state-pruning archive --trie-cache-size 1073741824 --db-cache 8000 ----name="TestNode (Embedded Relay)"</span>
+     <span data-ty="input"><span class="file-path"></span>docker run --network="host" -v "/var/lib/alphanet-data:/d ata" -u $(id-u ${USER}):$(id -g #{USER}) moonbeam-foundation/moonbeam:v0.47.0 --base-path=/d ata --chain alphanet --name="TestNode" --state-pruning archive --trie-cache-size 1073741824 --db-cache 8000 ----name="TestNode (Embedded Relay)"</span>
     <span data-ty>2025-07-10 09:04:26 Moonbeam Parachain Collator </span>
     <span data-ty>2025-07-10 09:04:26 ✌️  version 0.46.0-d7df89e7161 </span>
     <span data-ty>2025-07-10 09:04:26 ❤️  by PureStake, 2019-2025 </span>
@@ -3108,7 +3108,7 @@ You should see a terminal log similar to the following if you spun up a Moonbase
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --network host  \
     <br>-u $(id -u ${USER}):$(id -g ${USER}) \
-        moonbeamfoundation/moonbeam-tracing:v0.45.0-3701-a160 \
+        moonbeamfoundation/moonbeam-tracing:v0.47.0-3900-b897 \
     <br>--name="Moonbean-Tracing-Tutorial" \
     <br>--unsafe-rpc-external \
     <br>--ethapi=debug,trace,txpool \
@@ -7635,9 +7635,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -7646,8 +7646,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -7684,7 +7684,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-oracle-nodes.txt
+++ b/llms-files/llms-oracle-nodes.txt
@@ -5299,9 +5299,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -5310,8 +5310,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -5348,7 +5348,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-precompiles.txt
+++ b/llms-files/llms-precompiles.txt
@@ -15720,9 +15720,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -15731,8 +15731,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -15769,7 +15769,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-staking.txt
+++ b/llms-files/llms-staking.txt
@@ -10503,9 +10503,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -10514,8 +10514,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -10552,7 +10552,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-substrate-toolkit.txt
+++ b/llms-files/llms-substrate-toolkit.txt
@@ -17779,9 +17779,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -17790,8 +17790,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -17828,7 +17828,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-tokens-and-accounts.txt
+++ b/llms-files/llms-tokens-and-accounts.txt
@@ -8645,9 +8645,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -8656,8 +8656,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -8694,7 +8694,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-tutorials.txt
+++ b/llms-files/llms-tutorials.txt
@@ -6655,7 +6655,7 @@ This will start up our development node, which can be accessed on port 9944. Not
 
 <div id="termynal" data-termynal>
     <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development -p 9944:9944 \</span>
-    <span data-ty>moonbeamfoundation/moonbeam:v0.45.0 \</span>
+    <span data-ty>moonbeamfoundation/moonbeam:v0.47.0 \</span>
     <span data-ty>--dev --rpc-external</span>
     <span data-ty>2025-07-10 09:04:26 Moonbeam Parachain Collator</span>
     <span data-ty>2025-07-10 09:04:26 ✌️  version 0.46.0-d7df89e7161</span>
@@ -18679,9 +18679,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -18690,8 +18690,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -18728,7 +18728,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-xc-20.txt
+++ b/llms-files/llms-xc-20.txt
@@ -7143,9 +7143,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -7154,8 +7154,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -7192,7 +7192,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-xcm-remote-execution.txt
+++ b/llms-files/llms-xcm-remote-execution.txt
@@ -7624,9 +7624,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -7635,8 +7635,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -7673,7 +7673,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/llms-files/llms-xcm.txt
+++ b/llms-files/llms-xcm.txt
@@ -9707,9 +9707,9 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     The tail end of the console log should look like this:
 
     <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.43.0</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moonbeamfoundation/moonbeam:v0.47.0</span>
   <br>
-  <span data-ty>v0.43.0: Pulling from moonbeamfoundation/moonbeam
+  <span data-ty>v0.47.0: Pulling from moonbeamfoundation/moonbeam
     <br> b0a0cf830b12: Pull complete
     <br> fbff687640dd: Pull complete
     <br> 58ea427410e2: Pull complete
@@ -9718,8 +9718,8 @@ Using Docker enables you to spin up a node in a matter of seconds. Once you have
     <br> 128693ce218e: Pull complete
     <br> a3ac90b88463: Pull complete
     <br> Digest: sha256:86421aca2381265cd2e5283cb98705e24be0bc92a73937363f79d9d6e0d62088
-    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.43.0
-    <br> docker.io/moonbeamfoundation/moonbeam:v0.43.0
+    <br> Status: Downloaded newer image for moonbeamfoundation/moonbeam:v0.47.0
+    <br> docker.io/moonbeamfoundation/moonbeam:v0.47.0
   </span>
 </div>
 
@@ -9756,7 +9756,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>docker run --rm --name moonbeam_development --network host \
-    <br> moonbeamfoundation/moonbeam:v0.45.0 \
+    <br> moonbeamfoundation/moonbeam:v0.47.0 \
     <br> --dev --rpc-external
   </span>
   <br>

--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
-    build_tag: v0.46.0
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.46.0-3800-536b
+    build_tag: v0.47.0
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.47.0-3900-b897
     rpc_url: http://127.0.0.1:9944
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -16,9 +16,9 @@ networks:
     chain_spec: alphanet
     block_explorer: https://moonbase.moonscan.io/
     spec_version: runtime-3800
-    parachain_release_tag: v0.46.0 # must be in this exact format for links to work
-    parachain_sha256sum: 51d63742aa38a076ab105087c1fab7b82b7f5df368db41130a0e352f240ec0aa
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.46.0-3800-536b
+    parachain_release_tag: v0.47.0 # must be in this exact format for links to work
+    parachain_sha256sum: ca2c664c2bc9d5221130a412313aa05bac907c15c911fb09cdc9a0551893fa2e
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.47.0-3900-b897
     gas_block: 60,000,000
     gas_block_numbers_only: 60000000 # this should match gas_block, just with no commas
     gas_tx: 52,000,000 # EXTRINSIC_GAS_LIMIT in test/helpers/constants.ts
@@ -378,9 +378,9 @@ networks:
     chain_id: 1285
     hex_chain_id: '0x505'
     node_directory: /var/lib/moonriver-data
-    parachain_release_tag: v0.46.0
-    parachain_sha256sum: 51d63742aa38a076ab105087c1fab7b82b7f5df368db41130a0e352f240ec0aa
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.46.0-3800-536b
+    parachain_release_tag: v0.47.0
+    parachain_sha256sum: ca2c664c2bc9d5221130a412313aa05bac907c15c911fb09cdc9a0551893fa2e
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.47.0-3900-b897
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     spec_version: runtime-3800
@@ -732,9 +732,9 @@ networks:
     chain_id: 1284
     hex_chain_id: '0x504'
     node_directory: /var/lib/moonbeam-data
-    parachain_release_tag: v0.46.0
-    parachain_sha256sum: 51d63742aa38a076ab105087c1fab7b82b7f5df368db41130a0e352f240ec0aa
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.46.0-3800-536b
+    parachain_release_tag: v0.47.0
+    parachain_sha256sum: ca2c664c2bc9d5221130a412313aa05bac907c15c911fb09cdc9a0551893fa2e
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.47.0-3900-b897
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     spec_version: runtime-3800


### PR DESCRIPTION
### Description
Waiting for Runtime 3900 Schedule to be Released before merge. 

This pull request updates all documentation code snippets and examples to use the latest Moonbeam and Moonbeam Tracing Docker image versions (`v0.47.0` and `v0.47.0-3900-b897` respectively), replacing previous references to older versions. This ensures users are guided to use the most current images when following setup instructions, improving reliability and consistency across tutorials and guides.

**Moonbeam Docker image version updates:**

* Updated all `docker pull moonbeamfoundation/moonbeam` commands in documentation files to use `v0.47.0` instead of older versions like `v0.43.0` or `v0.45.0`. This affects files such as `llms-files/llms-basics.txt`, `llms-files/llms-dev-environments.txt`, `llms-files/llms-ethereum-toolkit.txt`, `llms-files/llms-gmp-providers.txt`, `llms-files/llms-governance.txt`, `llms-files/llms-indexers-and-queries.txt`, `llms-files/llms-integrations.txt`, and multiple `.snippets/code/builders/get-started/networks/moonbeam-dev/terminal/docker-pull.md` entries. [[1]](diffhunk://#diff-6d86b9f05272950ce32743b170bb3b29ca78ffa07092054b92afd703ddf156e6L4275-R4277) [[2]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL10716-R10718) [[3]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206L25890-R25892) [[4]](diffhunk://#diff-19c9d4f23cc0fab01e2f310a9e6f87055fd7c7a573f2362bfcb9ea50556b3154L5344-R5346) [[5]](diffhunk://#diff-175e47e31d26a19d2b696b1ce853767a65d6edf2e25272c5af80c5c6f89c47faL5043-R5045) [[6]](diffhunk://#diff-47a2d2044b87459f9ac7f92f6e999b2f578044c372107befb95826b4a44ff953L6797-R6799) [[7]](diffhunk://#diff-7af969f1f09862a8a477fb742a20c60a26b726a3fe8065169d0a16099249cd35L4926-R4928) [[8]](diffhunk://#diff-6658df7e8a542f9c645300b6b5399ffef6b909856c5f38a71ad715f6666399afL2-R4)

* Updated all sample output and status lines to reflect the new image version (`v0.47.0`) for consistency in the documentation. [[1]](diffhunk://#diff-6d86b9f05272950ce32743b170bb3b29ca78ffa07092054b92afd703ddf156e6L4286-R4287) [[2]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL10727-R10728) [[3]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206L25901-R25902) [[4]](diffhunk://#diff-19c9d4f23cc0fab01e2f310a9e6f87055fd7c7a573f2362bfcb9ea50556b3154L5355-R5356) [[5]](diffhunk://#diff-175e47e31d26a19d2b696b1ce853767a65d6edf2e25272c5af80c5c6f89c47faL5054-R5055) [[6]](diffhunk://#diff-47a2d2044b87459f9ac7f92f6e999b2f578044c372107befb95826b4a44ff953L6808-R6809) [[7]](diffhunk://#diff-7af969f1f09862a8a477fb742a20c60a26b726a3fe8065169d0a16099249cd35L4937-R4938) [[8]](diffhunk://#diff-6658df7e8a542f9c645300b6b5399ffef6b909856c5f38a71ad715f6666399afL13-R14)

**Moonbeam Docker run command updates:**

* Changed all `docker run` commands to use `moonbeamfoundation/moonbeam:v0.47.0` for starting development nodes, replacing older versions in all related documentation and snippet files. [[1]](diffhunk://#diff-6d86b9f05272950ce32743b170bb3b29ca78ffa07092054b92afd703ddf156e6L4324-R4324) [[2]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL10765-R10765) [[3]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206L25939-R25939) [[4]](diffhunk://#diff-19c9d4f23cc0fab01e2f310a9e6f87055fd7c7a573f2362bfcb9ea50556b3154L5393-R5393) [[5]](diffhunk://#diff-175e47e31d26a19d2b696b1ce853767a65d6edf2e25272c5af80c5c6f89c47faL5092-R5092) [[6]](diffhunk://#diff-47a2d2044b87459f9ac7f92f6e999b2f578044c372107befb95826b4a44ff953L6846-R6846) [[7]](diffhunk://#diff-7af969f1f09862a8a477fb742a20c60a26b726a3fe8065169d0a16099249cd35L4975-R4975) [[8]](diffhunk://#diff-eb19d8433782c9d4ee07442cae39ca6b945529ba231b32e76a1748f0dde1edfdL3-R3) [[9]](diffhunk://#diff-03864d5494b690ffa74d2d1b36143d845d76181767423b0ecff0b9f0ba8cc2feL3-R3) [[10]](diffhunk://#diff-54a22a20c7cd30b5a75c7bcfac917cda3a0483cf13cf5a2e498b1067471045f3L2-R2)

**Moonbeam Tracing Docker image update:**

* Updated the Moonbeam Tracing Docker image in all relevant snippets from `v0.45.0-3701-a160` to `v0.47.0-3900-b897`, ensuring tracing tutorials use the latest version. [[1]](diffhunk://#diff-dd283e28d7d6e4555306dd606e3fa2b1c767e28afbbd9b886bd802ffb78bc2c1L4-R4) [[2]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206L4349-R4349)

These updates help keep all documentation and tutorials aligned with the latest Moonbeam releases, reducing confusion and potential issues for developers following setup instructions.

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
