### PR TITLE
Hardhat Revisions

### DIFF
--- a/.snippets/code/builders/ethereum/dev-env/hardhat/terminal/hardhat-create.md
+++ b/.snippets/code/builders/ethereum/dev-env/hardhat/terminal/hardhat-create.md
@@ -9,7 +9,11 @@
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;Y88b&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;Y88b.</span>
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Y88888&nbsp;888&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;&nbsp;"Y888</span>
     <br>
-  <span data-ty>👷 Welcome to Hardhat v3.0.0-next.5 👷‍</span>
+  <span data-ty>👷 Welcome to Hardhat v3.0.4 👷‍</span>
+    <br>
+  <span data-ty="input" data-ty-prompt="?">&nbsp;Which version of Hardhat would you like to use? …</span>
+  <span data-ty="input" data-ty-prompt="❯">&nbsp;Hardhat 3 Beta (recommended for new projects)</span>
+  <span data-ty>&nbsp;&nbsp;Hardhat 2 (older version)</span>
     <br>
   <span data-ty="input" data-ty-prompt="✔">&nbsp;Where would you like to initialize the project?</span>
   <span data-ty="input" data-ty-prompt="Please provide either a relative or an absolute path:">&nbsp;.</span>

--- a/.snippets/code/tutorials/eth-api/hardhat-start-to-end/terminal/hardhat-create.md
+++ b/.snippets/code/tutorials/eth-api/hardhat-start-to-end/terminal/hardhat-create.md
@@ -9,7 +9,11 @@
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;Y88b&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;Y88b.</span>
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Y88888&nbsp;888&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;&nbsp;"Y888</span>
     <br>
-  <span data-ty>👷 Welcome to Hardhat v3.0.0-next.5 👷‍</span>
+  <span data-ty>👷 Welcome to Hardhat v3.0.4 👷‍</span>
+    <br>
+  <span data-ty="input" data-ty-prompt="?">&nbsp;Which version of Hardhat would you like to use? …</span>
+  <span data-ty="input" data-ty-prompt="❯">&nbsp;Hardhat 3 Beta (recommended for new projects)</span>
+  <span data-ty>&nbsp;&nbsp;Hardhat 2 (older version)</span>
     <br>
   <span data-ty="input" data-ty-prompt="✔">&nbsp;Where would you like to initialize the project?</span>
   <span data-ty="input" data-ty-prompt="Please provide either a relative or an absolute path:">&nbsp;.</span>

--- a/builders/ethereum/dev-env/hardhat.md
+++ b/builders/ethereum/dev-env/hardhat.md
@@ -47,7 +47,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 3. Install Hardhat
 
     ```sh
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
 4. Create a Hardhat project
@@ -62,6 +62,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
+    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:
@@ -103,19 +104,19 @@ Next, you'll need to modify your configuration file to add the network configura
 Hardhat 3 includes an encrypted secrets manager that makes it easier to handle sensitive information like private keys. This ensures you don't have to hardcode secrets in your source code or store them in plain text.
 
 !!! note
-    The encrypted secrets manager is only available in Hardhat 3 or higher. As of writing this guide, Hardhat 3 is in alpha. You can install the latest alpha version with:
+    The encrypted secrets manager is only available in Hardhat 3 or higher. You can install the latest version with:
 
     ```bash
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
     For the latest releases and updates, check the [Hardhat releases page](https://github.com/NomicFoundation/hardhat/releases/).
 
 To use encrypted secrets, you'll need to:
 
-1. Install Hardhat 3 or later:
+1. Install Hardhat (latest version):
 ```bash
-npm install hardhat@3.0.0-next.5
+npm install hardhat
 ```
 
 2. Set up your secrets using the keystore:

--- a/builders/ethereum/dev-env/hardhat.md
+++ b/builders/ethereum/dev-env/hardhat.md
@@ -62,7 +62,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
-    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
+    - Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:

--- a/llms-files/llms-dev-environments.txt
+++ b/llms-files/llms-dev-environments.txt
@@ -1406,7 +1406,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
-    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
+    - Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:
@@ -5138,7 +5138,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
-    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
+    - Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:

--- a/llms-files/llms-dev-environments.txt
+++ b/llms-files/llms-dev-environments.txt
@@ -1391,7 +1391,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 3. Install Hardhat
 
     ```sh
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
 4. Create a Hardhat project
@@ -1406,6 +1406,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
+    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:
@@ -1432,7 +1433,11 @@ You will need to create a Hardhat project if you don't already have one. You can
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;Y88b&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;Y88b.</span>
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Y88888&nbsp;888&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;&nbsp;"Y888</span>
     <br>
-  <span data-ty>👷 Welcome to Hardhat v3.0.0-next.5 👷‍</span>
+  <span data-ty>👷 Welcome to Hardhat v3.0.4 👷‍</span>
+    <br>
+  <span data-ty="input" data-ty-prompt="?">&nbsp;Which version of Hardhat would you like to use? …</span>
+  <span data-ty="input" data-ty-prompt="❯">&nbsp;Hardhat 3 Beta (recommended for new projects)</span>
+  <span data-ty>&nbsp;&nbsp;Hardhat 2 (older version)</span>
     <br>
   <span data-ty="input" data-ty-prompt="✔">&nbsp;Where would you like to initialize the project?</span>
   <span data-ty="input" data-ty-prompt="Please provide either a relative or an absolute path:">&nbsp;.</span>
@@ -1466,19 +1471,19 @@ Next, you'll need to modify your configuration file to add the network configura
 Hardhat 3 includes an encrypted secrets manager that makes it easier to handle sensitive information like private keys. This ensures you don't have to hardcode secrets in your source code or store them in plain text.
 
 !!! note
-    The encrypted secrets manager is only available in Hardhat 3 or higher. As of writing this guide, Hardhat 3 is in alpha. You can install the latest alpha version with:
+    The encrypted secrets manager is only available in Hardhat 3 or higher. You can install the latest version with:
 
     ```bash
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
     For the latest releases and updates, check the [Hardhat releases page](https://github.com/NomicFoundation/hardhat/releases/).
 
 To use encrypted secrets, you'll need to:
 
-1. Install Hardhat 3 or later:
+1. Install Hardhat (latest version):
 ```bash
-npm install hardhat@3.0.0-next.5
+npm install hardhat
 ```
 
 2. Set up your secrets using the keystore:
@@ -5119,7 +5124,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 3. Install Hardhat
 
     ```bash
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
 4. Create a project
@@ -5133,6 +5138,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
+    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:
@@ -5159,7 +5165,11 @@ You will need to create a Hardhat project if you don't already have one. You can
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;Y88b&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;Y88b.</span>
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Y88888&nbsp;888&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;&nbsp;"Y888</span>
     <br>
-  <span data-ty>👷 Welcome to Hardhat v3.0.0-next.5 👷‍</span>
+  <span data-ty>👷 Welcome to Hardhat v3.0.4 👷‍</span>
+    <br>
+  <span data-ty="input" data-ty-prompt="?">&nbsp;Which version of Hardhat would you like to use? …</span>
+  <span data-ty="input" data-ty-prompt="❯">&nbsp;Hardhat 3 Beta (recommended for new projects)</span>
+  <span data-ty>&nbsp;&nbsp;Hardhat 2 (older version)</span>
     <br>
   <span data-ty="input" data-ty-prompt="✔">&nbsp;Where would you like to initialize the project?</span>
   <span data-ty="input" data-ty-prompt="Please provide either a relative or an absolute path:">&nbsp;.</span>
@@ -5744,19 +5754,19 @@ If you're curious about additional Hardhat plugins, here is [a complete list of 
 Hardhat 3 includes an encrypted secrets manager that makes handling sensitive information like private keys and API keys easier. This ensures you don't have to hardcode secrets in your source code or store them in plain text.
 
 !!! note
-    The encrypted secrets manager is only available in Hardhat 3 or higher. As of writing this guide, Hardhat 3 is in alpha. You can install the latest alpha version with:
+    The encrypted secrets manager is only available in Hardhat 3 or higher. You can install the latest version with:
 
     ```bash
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
     For the latest releases and updates, check the [Hardhat releases page](https://github.com/NomicFoundation/hardhat/releases/).
 
 To use encrypted secrets, you'll need to:
 
-1. Install Hardhat 3 or later:
+1. Install Hardhat (latest version):
 ```bash
-npm install hardhat@3.0.0-next.5
+npm install hardhat
 ```
 
 2. Set up your secrets using the keystore:

--- a/llms-files/llms-ethereum-toolkit.txt
+++ b/llms-files/llms-ethereum-toolkit.txt
@@ -1662,7 +1662,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
-    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
+    - Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:

--- a/llms-files/llms-ethereum-toolkit.txt
+++ b/llms-files/llms-ethereum-toolkit.txt
@@ -1647,7 +1647,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 3. Install Hardhat
 
     ```sh
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
 4. Create a Hardhat project
@@ -1662,6 +1662,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
+    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:
@@ -1688,7 +1689,11 @@ You will need to create a Hardhat project if you don't already have one. You can
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;Y88b&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;Y88b.</span>
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Y88888&nbsp;888&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;&nbsp;"Y888</span>
     <br>
-  <span data-ty>👷 Welcome to Hardhat v3.0.0-next.5 👷‍</span>
+  <span data-ty>👷 Welcome to Hardhat v3.0.4 👷‍</span>
+    <br>
+  <span data-ty="input" data-ty-prompt="?">&nbsp;Which version of Hardhat would you like to use? …</span>
+  <span data-ty="input" data-ty-prompt="❯">&nbsp;Hardhat 3 Beta (recommended for new projects)</span>
+  <span data-ty>&nbsp;&nbsp;Hardhat 2 (older version)</span>
     <br>
   <span data-ty="input" data-ty-prompt="✔">&nbsp;Where would you like to initialize the project?</span>
   <span data-ty="input" data-ty-prompt="Please provide either a relative or an absolute path:">&nbsp;.</span>
@@ -1722,19 +1727,19 @@ Next, you'll need to modify your configuration file to add the network configura
 Hardhat 3 includes an encrypted secrets manager that makes it easier to handle sensitive information like private keys. This ensures you don't have to hardcode secrets in your source code or store them in plain text.
 
 !!! note
-    The encrypted secrets manager is only available in Hardhat 3 or higher. As of writing this guide, Hardhat 3 is in alpha. You can install the latest alpha version with:
+    The encrypted secrets manager is only available in Hardhat 3 or higher. You can install the latest version with:
 
     ```bash
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
     For the latest releases and updates, check the [Hardhat releases page](https://github.com/NomicFoundation/hardhat/releases/).
 
 To use encrypted secrets, you'll need to:
 
-1. Install Hardhat 3 or later:
+1. Install Hardhat (latest version):
 ```bash
-npm install hardhat@3.0.0-next.5
+npm install hardhat
 ```
 
 2. Set up your secrets using the keystore:

--- a/llms-files/llms-tutorials.txt
+++ b/llms-files/llms-tutorials.txt
@@ -2232,7 +2232,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 3. Install Hardhat
 
     ```bash
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
 4. Create a project
@@ -2246,6 +2246,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
+    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:
@@ -2272,7 +2273,11 @@ You will need to create a Hardhat project if you don't already have one. You can
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;Y88b&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;888&nbsp;&nbsp;888&nbsp;Y88b.</span>
   <span data-ty>888&nbsp;&nbsp;&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;888&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Y88888&nbsp;888&nbsp;&nbsp;888&nbsp;"Y888888&nbsp;&nbsp;"Y888</span>
     <br>
-  <span data-ty>👷 Welcome to Hardhat v3.0.0-next.5 👷‍</span>
+  <span data-ty>👷 Welcome to Hardhat v3.0.4 👷‍</span>
+    <br>
+  <span data-ty="input" data-ty-prompt="?">&nbsp;Which version of Hardhat would you like to use? …</span>
+  <span data-ty="input" data-ty-prompt="❯">&nbsp;Hardhat 3 Beta (recommended for new projects)</span>
+  <span data-ty>&nbsp;&nbsp;Hardhat 2 (older version)</span>
     <br>
   <span data-ty="input" data-ty-prompt="✔">&nbsp;Where would you like to initialize the project?</span>
   <span data-ty="input" data-ty-prompt="Please provide either a relative or an absolute path:">&nbsp;.</span>
@@ -2857,19 +2862,19 @@ If you're curious about additional Hardhat plugins, here is [a complete list of 
 Hardhat 3 includes an encrypted secrets manager that makes handling sensitive information like private keys and API keys easier. This ensures you don't have to hardcode secrets in your source code or store them in plain text.
 
 !!! note
-    The encrypted secrets manager is only available in Hardhat 3 or higher. As of writing this guide, Hardhat 3 is in alpha. You can install the latest alpha version with:
+    The encrypted secrets manager is only available in Hardhat 3 or higher. You can install the latest version with:
 
     ```bash
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
     For the latest releases and updates, check the [Hardhat releases page](https://github.com/NomicFoundation/hardhat/releases/).
 
 To use encrypted secrets, you'll need to:
 
-1. Install Hardhat 3 or later:
+1. Install Hardhat (latest version):
 ```bash
-npm install hardhat@3.0.0-next.5
+npm install hardhat
 ```
 
 2. Set up your secrets using the keystore:

--- a/llms-files/llms-tutorials.txt
+++ b/llms-files/llms-tutorials.txt
@@ -2246,7 +2246,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
-    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
+    - Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:

--- a/tutorials/eth-api/hardhat-start-to-end.md
+++ b/tutorials/eth-api/hardhat-start-to-end.md
@@ -46,7 +46,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 3. Install Hardhat
 
     ```bash
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
 4. Create a project
@@ -60,6 +60,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
+    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:
@@ -139,19 +140,19 @@ If you're curious about additional Hardhat plugins, here is [a complete list of 
 Hardhat 3 includes an encrypted secrets manager that makes handling sensitive information like private keys and API keys easier. This ensures you don't have to hardcode secrets in your source code or store them in plain text.
 
 !!! note
-    The encrypted secrets manager is only available in Hardhat 3 or higher. As of writing this guide, Hardhat 3 is in alpha. You can install the latest alpha version with:
+    The encrypted secrets manager is only available in Hardhat 3 or higher. You can install the latest version with:
 
     ```bash
-    npm install hardhat@3.0.0-next.5
+    npm install hardhat
     ```
 
     For the latest releases and updates, check the [Hardhat releases page](https://github.com/NomicFoundation/hardhat/releases/).
 
 To use encrypted secrets, you'll need to:
 
-1. Install Hardhat 3 or later:
+1. Install Hardhat (latest version):
 ```bash
-npm install hardhat@3.0.0-next.5
+npm install hardhat
 ```
 
 2. Set up your secrets using the keystore:

--- a/tutorials/eth-api/hardhat-start-to-end.md
+++ b/tutorials/eth-api/hardhat-start-to-end.md
@@ -60,7 +60,7 @@ You will need to create a Hardhat project if you don't already have one. You can
 
 5. You'll be prompted with a series of questions to set up your project:
 
-    - **Select Hardhat version**: Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
+    - Choose **Hardhat 3 Beta (recommended for new projects)** rather than Hardhat 2
     - Choose where to initialize the project (default is current directory)
     - Confirm converting to ESM (required for Hardhat v3)
     - Select the type of project to initialize:


### PR DESCRIPTION
### Description

This pull request updates documentation and tutorial files to reference the latest Hardhat version (v3.0.4) and improves instructions for initializing Hardhat projects. The changes ensure users install the stable release and clarify the project setup flow, including a new prompt to select the Hardhat version. The encrypted secrets manager instructions are also updated to reflect the current release status.

**Hardhat installation and versioning:**

* Updated all references to install Hardhat from `npm install hardhat@3.0.0-next.5` to `npm install hardhat`, ensuring users get the latest stable version instead of the previous alpha/next release. [[1]](diffhunk://#diff-81d3ffdf236d4f7980aefa47c8aabff7669600d77b61124a80eb8cb52d854464L50-R50) [[2]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL1394-R1394) [[3]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL5122-R5127) [[4]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206L1650-R1650) [[5]](diffhunk://#diff-d48e31b9c6e4f434f50851828d324b61f5325b0b87103c0d1a6f093d57fcff9aL2235-R2235) [[6]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L2905-R2905)
* Changed all welcome and initialization prompts to show Hardhat v3.0.4 and added a new interactive prompt for selecting Hardhat 3 Beta or Hardhat 2 during project setup. [[1]](diffhunk://#diff-6be70d2f407bb22ac4e09be742ec784c0f78a0aa637c4e6ef8074b6045a6ac52L12-R16) [[2]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL1435-R1440) [[3]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL5162-R5172) [[4]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206L1691-R1696) [[5]](diffhunk://#diff-d48e31b9c6e4f434f50851828d324b61f5325b0b87103c0d1a6f093d57fcff9aL2275-R2280) [[6]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L2946-R2951)

**Project initialization instructions:**

* Added instructions to select "Hardhat 3 Beta (recommended for new projects)" during setup, making the recommended choice explicit for new users. [[1]](diffhunk://#diff-81d3ffdf236d4f7980aefa47c8aabff7669600d77b61124a80eb8cb52d854464R65) [[2]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dR1409) [[3]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dR5141) [[4]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206R1665) [[5]](diffhunk://#diff-d48e31b9c6e4f434f50851828d324b61f5325b0b87103c0d1a6f093d57fcff9aR2249) [[6]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714R2920)

**Encrypted secrets manager documentation:**

* Updated encrypted secrets manager instructions to reference the latest Hardhat release, removing outdated notes about the alpha status and ensuring installation commands use the stable version. [[1]](diffhunk://#diff-81d3ffdf236d4f7980aefa47c8aabff7669600d77b61124a80eb8cb52d854464L106-R119) [[2]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL1469-R1486) [[3]](diffhunk://#diff-144856fcb72436b4ca5a91c953e393d2a09b70640377d92b0d70d25e4f70857dL5747-R5769) [[4]](diffhunk://#diff-bc5a88b2142c425bed3867f4304f1475319b70c124d66bd644a0043d549c4206L1725-R1742) [[5]](diffhunk://#diff-d48e31b9c6e4f434f50851828d324b61f5325b0b87103c0d1a6f093d57fcff9aL2860-R2877)

These updates provide a clearer, more accurate onboarding experience for new Hardhat users and ensure documentation aligns with current best practices and available features.

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
