### PR TITLE
Add ethfaucet.com faucet

### DIFF
--- a/builders/get-started/networks/moonbase.md
+++ b/builders/get-started/networks/moonbase.md
@@ -50,6 +50,8 @@ To request DEV tokens from the faucet, you can enter your address on the [Moonba
 
 ![Moonbase Alpha Faucet Website.](/images/builders/get-started/networks/moonbase/moonbase-1.webp)
 
+Alternatively, use [ethfaucet.com](https://ethfaucet.com?utm_source=moonbeam_docs&utm_medium=docs).
+
 !!! note
     Moonbase Alpha DEV tokens have no value. Please don't spam the faucet with unnecessary requests.
 


### PR DESCRIPTION
Description
Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with gas on Moonbase Alpha network for free, claimable once every 24 hours.

Additional context
ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.
