### PR TITLE
Update Tracing tag

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
     build_tag: v0.49.2
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.49.2-4100-4d7b
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.49.2-4101-4c40
     rpc_url: http://127.0.0.1:9944
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -18,7 +18,7 @@ networks:
     spec_version: runtime-4100
     parachain_release_tag: v0.49.2 # Required format for link generation system
     parachain_sha256sum: 88fd7e94f257c5bff7a2b4fbe3dc1c00fd24fcc4943440a03e059778dfcb266d
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.49.2-4100-4d7b
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.49.2-4101-4c40
     gas_block: 60,000,000
     gas_block_numbers_only: 60000000 # this should match gas_block, just with no commas
     gas_tx: 52,000,000 # EXTRINSIC_GAS_LIMIT in test/helpers/constants.ts
@@ -376,7 +376,7 @@ networks:
     node_directory: /var/lib/moonriver-data
     parachain_release_tag: v0.49.2
     parachain_sha256sum: 88fd7e94f257c5bff7a2b4fbe3dc1c00fd24fcc4943440a03e059778dfcb266d
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.49.2-4100-4d7b
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.49.2-4101-4c40
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     spec_version: runtime-4000
@@ -729,7 +729,7 @@ networks:
     node_directory: /var/lib/moonbeam-data
     parachain_release_tag: v0.49.2
     parachain_sha256sum: 88fd7e94f257c5bff7a2b4fbe3dc1c00fd24fcc4943440a03e059778dfcb266d
-    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.49.2-4100-4d7b
+    tracing_tag: moonbeamfoundation/moonbeam-tracing:v0.49.2-4101-4c40
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     spec_version: runtime-4001


### PR DESCRIPTION
### Description

This pull request updates the `tracing_tag` value for several network configurations in the `variables.yml` file. The new tag points to a newer version of the `moonbeamfoundation/moonbeam-tracing` image, ensuring all relevant networks use the updated tracing image.

Network configuration updates:

* Updated the `tracing_tag` for the `development` network to `moonbeamfoundation/moonbeam-tracing:v0.49.2-4101-4c40`.
* Updated the `tracing_tag` for the `moonbase` network to `moonbeamfoundation/moonbeam-tracing:v0.49.2-4101-4c40`.
* Updated the `tracing_tag` for the `moonriver` network to `moonbeamfoundation/moonbeam-tracing:v0.49.2-4101-4c40`.
* Updated the `tracing_tag` for the `moonbeam` network to `moonbeamfoundation/moonbeam-tracing:v0.49.2-4101-4c40`.

### Checklist

- [x] Added a label 🏷️ to this PR
- [ ] Ran my changes through Grammarly
- [ ] Added a disclaimer if required
- [ ] If pages were moved, opened a corresponding PR in [`moonbeam-mkdocs`](https://github.com/papermoonio/moonbeam-mkdocs) to update redirects

---

### Translations

Does this PR update a page that also exists on the Chinese docs site? See [mapping](https://github.com/moonbeam-foundation/moonbeam-docs/blob/master/js/handleLanguageChange.js#L8-L41) to confirm.

- [ ] Yes
- [ ] No

If **Yes**, complete the following:

- [ ] Opened a PR on the [Chinese docs repo](https://github.com/moonbeam-foundation/moonbeam-docs-cn) for the corresponding page
- [ ] Updated images, snippets, or variables if they were moved, renamed, or deleted

Link to the corresponding CN docs PR: <INSERT_LINK>
