### PR TITLE
Fix minor documentation typos

### DIFF
--- a/.CONTRIBUTING.md
+++ b/.CONTRIBUTING.md
@@ -127,7 +127,7 @@ To link to a snippet, you can use the following syntax in the Markdown file:
 
 Code snippets can be written in Markdown or the programming language itself, for example, `.py` for Python, `.js` for JavaScript, etc.
 
-## Search Enging Optimization (SEO)
+## Search Engine Optimization (SEO)
 
 Here are some resources to help you create good titles and descriptions for SEO:
 

--- a/builders/ethereum/libraries/web3py.md
+++ b/builders/ethereum/libraries/web3py.md
@@ -1,6 +1,6 @@
 ---
 title: How to use Web3.py Ethereum Library
-description: Follow this tutorial to learn how to use the Ethereum Web3 Python Library to to send transactions and deploy Solidity smart contracts to Moonbeam.
+description: Follow this tutorial to learn how to use the Ethereum Web3 Python Library to send transactions and deploy Solidity smart contracts to Moonbeam.
 categories: Libraries and SDKs, Ethereum Toolkit
 ---
 

--- a/builders/ethereum/precompiles/ux/call-permit.md
+++ b/builders/ethereum/precompiles/ux/call-permit.md
@@ -43,7 +43,7 @@ The Call Permit Precompile is located at the following address:
 
 The interface includes the following functions:
 
-??? function "**dispatch**(*address* from, *address* to, *uint256* value, *bytes* data, *uint64[]* gaslimit, *uint256* deadline, *uint8* v, *bytes32* r, *bytes32* s) - dispatches a call on the behalf of another user with a EIP-712 permit. This function can be called by anyone or any smart contract. The transaction will revert if the permit is not valid or if the dispatched call reverts or errors (such as out of gas). If successful, the nonce of the signer is increased to prevent this permit to be replayed"
+??? function "**dispatch**(*address* from, *address* to, *uint256* value, *bytes* data, *uint64[]* gaslimit, *uint256* deadline, *uint8* v, *bytes32* r, *bytes32* s) - dispatches a call on the behalf of another user with an EIP-712 permit. This function can be called by anyone or any smart contract. The transaction will revert if the permit is not valid or if the dispatched call reverts or errors (such as out of gas). If successful, the nonce of the signer is increased to prevent this permit to be replayed"
 
     === "Parameters"
 

--- a/builders/interoperability/xcm/xc20/send-xc20s/overview.md
+++ b/builders/interoperability/xcm/xc20/send-xc20s/overview.md
@@ -17,7 +17,7 @@ Assets can move between parachains using XCM. Two main approaches exist:
 
 Moonbeam currently uses remote transfers for XC-20 transfers.
 
-This page covers the fundamentals of XCM-based remote transfers. To learn how to perform XC-20 transfers, refer to the the [XC-20 transfers via the Substrate API](/builders/interoperability/xcm/xc20/send-xc20s/xcm-pallet/){target=\_blank} guide.
+This page covers the fundamentals of XCM-based remote transfers. To learn how to perform XC-20 transfers, refer to the [XC-20 transfers via the Substrate API](/builders/interoperability/xcm/xc20/send-xc20s/xcm-pallet/){target=\_blank} guide.
 
 ## XCM Instructions for Asset Transfers {: #xcm-instructions-for-asset-transfers }
 


### PR DESCRIPTION
### Description

Fix a few minor documentation typos and duplicated words.

### Checklist

- [ ] Added a label 🏷️ to this PR
- [ ] Ran my changes through Grammarly
- [ ] Added a disclaimer if required
- [ ] If pages were moved, opened a corresponding PR in [`moonbeam-mkdocs`](https://github.com/papermoonio/moonbeam-mkdocs) to update redirects

---

### Translations

Does this PR update a page that also exists on the Chinese docs site? See [mapping](https://github.com/moonbeam-foundation/moonbeam-docs/blob/master/js/handleLanguageChange.js#L8-L41) to confirm.

- [ ] Yes
- [ ] No

If **Yes**, complete the following:

- [ ] Opened a PR on the [Chinese docs repo](https://github.com/moonbeam-foundation/moonbeam-docs-cn) for the corresponding page
- [ ] Updated images, snippets, or variables if they were moved, renamed, or deleted

Link to the corresponding CN docs PR: <INSERT_LINK>
